### PR TITLE
Db refractor

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
 [env]
-RUST_LOG = "warn,cosmic_ext_applet_clipboard_manager=debug"
+RUST_LOG = "warn,cosmic_ext_applet_clipboard_manager=info"
 # RUST_BACKTRACE = "full"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,8 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 [[package]]
 name = "alive_lock_file"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5639bdca4a334142d2efc8a192cff12ae003e42cf19e8a45f24246eb244f3cc"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "nucleo",
  "os_pipe",
  "paste",
+ "regex",
  "rust-embed",
  "serde",
  "serial_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "jobserver",
  "libc",
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1161,7 +1161,7 @@ dependencies = [
  "serde",
  "serial_test",
  "sqlx",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
  "tracing",
  "tracing-journald",
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1286,18 +1286,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1314,18 +1314,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -2397,11 +2397,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2518,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -2551,7 +2551,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "futures",
  "iced_core",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3172,7 +3172,7 @@ checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#2c29a7b158d07f4479e20268ddae4e4860903a2d"
+source = "git+https://github.com/pop-os/libcosmic#aeb87f88865a92fee6b96e061f618d20abe59aaa"
 dependencies = [
  "apply",
  "ashpd 0.9.2",
@@ -4838,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b202022bb57c049555430e11fc22fea12909276a80a4c3d368da36ac1d88ed"
+checksum = "94b13f8ea6177672c49d12ed964cca44836f59621981b04a3e26b87e675181de"
 dependencies = [
  "sdd",
 ]
@@ -4897,9 +4897,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
+checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
 
 [[package]]
 name = "self_cell"
@@ -5642,11 +5642,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.7",
 ]
 
 [[package]]
@@ -5662,9 +5662,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6948,14 +6948,14 @@ dependencies = [
 [[package]]
 name = "wl-clipboard-rs"
 version = "0.8.1"
-source = "git+https://github.com/wiiznokes/wl-clipboard-rs.git?branch=watch#2c10217b78dee4fe6435f29e263450da5398eb8e"
+source = "git+https://github.com/wiiznokes/wl-clipboard-rs.git?branch=watch#fa84b41ab555189bad1b25fa084b0ffb6a33cd97"
 dependencies = [
  "libc",
  "log",
  "os_pipe",
  "rustix 0.38.42",
  "tempfile",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
  "tree_magic_mini",
  "wayland-backend",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "wl-clipboard-rs"
 version = "0.8.1"
-source = "git+https://github.com/wiiznokes/wl-clipboard-rs.git?branch=watch#10d95f5d5e22d062e51782d4270291295216c4e7"
+source = "git+https://github.com/wiiznokes/wl-clipboard-rs.git?branch=watch#2c10217b78dee4fe6435f29e263450da5398eb8e"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alive_lock_file"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "log",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1137,7 @@ dependencies = [
 name = "cosmic-ext-applet-clipboard-manager"
 version = "0.1.0"
 dependencies = [
+ "alive_lock_file",
  "anyhow",
  "chrono",
  "configurator_schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
  "url",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.5",
+ "wayland-protocols",
  "zbus 4.4.0",
 ]
 
@@ -1104,7 +1104,7 @@ dependencies = [
  "libc",
  "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client",
- "wayland-protocols 0.32.5",
+ "wayland-protocols",
 ]
 
 [[package]]
@@ -1192,7 +1192,7 @@ dependencies = [
  "serde",
  "smithay-client-toolkit 0.19.2 (git+https://github.com/Smithay/client-toolkit)",
  "tracing",
- "wayland-protocols-wlr 0.3.5",
+ "wayland-protocols-wlr",
  "xdg-shell-wrapper-config",
 ]
 
@@ -1204,8 +1204,8 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.5",
- "wayland-protocols-wlr 0.3.5",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "wayland-server",
 ]
@@ -2663,7 +2663,7 @@ dependencies = [
  "tiny-xlib",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.5",
+ "wayland-protocols",
  "wayland-sys",
  "wgpu",
  "x11rb",
@@ -2705,7 +2705,7 @@ dependencies = [
  "tracing",
  "wasm-bindgen-futures",
  "wayland-backend",
- "wayland-protocols 0.32.5",
+ "wayland-protocols",
  "web-sys",
  "winapi",
  "window_clipboard",
@@ -5148,8 +5148,8 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.32.5",
- "wayland-protocols-wlr 0.3.5",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "xkbcommon",
  "xkeysym",
@@ -5175,8 +5175,8 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.32.5",
- "wayland-protocols-wlr 0.3.5",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "xkbcommon",
  "xkeysym",
@@ -6320,18 +6320,6 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
 version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
@@ -6352,20 +6340,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.5",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -6378,7 +6353,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.5",
+ "wayland-protocols",
  "wayland-scanner",
  "wayland-server",
 ]
@@ -6941,7 +6916,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.5",
+ "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",
@@ -6972,19 +6947,20 @@ dependencies = [
 [[package]]
 name = "wl-clipboard-rs"
 version = "0.8.1"
-source = "git+https://github.com/wiiznokes/wl-clipboard-rs.git?branch=watch#45ccfaf4469585c520a2df2c63b13a7800627d9f"
+source = "git+https://github.com/wiiznokes/wl-clipboard-rs.git?branch=watch#10d95f5d5e22d062e51782d4270291295216c4e7"
 dependencies = [
  "libc",
  "log",
  "os_pipe",
  "rustix 0.38.42",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
+ "tokio",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
- "wayland-protocols-wlr 0.2.0",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]
@@ -7059,7 +7035,7 @@ version = "0.1.0"
 source = "git+https://github.com/pop-os/cosmic-panel#1c9c4e2a2cf27efd0ca77b5ec21bc6f7fa92d9da"
 dependencies = [
  "serde",
- "wayland-protocols-wlr 0.3.5",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ futures = "0.3"
 include_dir = "0.7"
 itertools = "0.13.0"
 alive_lock_file = "0.2"
+regex = "1"
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,17 +40,12 @@ nucleo = "0.5"
 futures = "0.3"
 include_dir = "0.7"
 itertools = "0.13.0"
-alive_lock_file = { path = "../alive_lock_file" }
+alive_lock_file = "0.2"
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic"
 default-features = false
-features = [
-    "applet",
-    "tokio",
-    "wayland",
-    "qr_code",
-]
+features = ["applet", "tokio", "wayland", "qr_code"]
 
 [dependencies.wl-clipboard-rs]
 git = "https://github.com/wiiznokes/wl-clipboard-rs.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,6 @@ features = ["applet", "tokio", "wayland", "qr_code"]
 [dependencies.wl-clipboard-rs]
 git = "https://github.com/wiiznokes/wl-clipboard-rs.git"
 branch = "watch"
-# path = "../wl-clipboard-rs"
-
-# [patch."https://github.com/pop-os/libcosmic".libcosmic]
-# git = "https://github.com/wiiznokes/libcosmic"
-# branch = "fix_qr_code_theme"
-# path = "../libcosmic"
 
 
 [dev-dependencies]
@@ -66,3 +60,11 @@ configurator_schema = { git = "https://github.com/cosmic-utils/configurator.git"
 [profile.release-lto]
 inherits = "release"
 lto = "fat"
+
+# [patch."https://github.com/pop-os/libcosmic".libcosmic]
+# git = "https://github.com/wiiznokes/libcosmic"
+# branch = "fix_qr_code_theme"
+# path = "../libcosmic"
+
+# [patch."https://github.com/wiiznokes/wl-clipboard-rs.git".wl-clipboard-rs]
+# path = "../wl-clipboard-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ nucleo = "0.5"
 futures = "0.3"
 include_dir = "0.7"
 itertools = "0.13.0"
+alive_lock_file = { path = "../alive_lock_file" }
+
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic"
 default-features = false

--- a/migrations/20240723123147_init.sql
+++ b/migrations/20240723123147_init.sql
@@ -1,11 +1,13 @@
 CREATE TABLE IF NOT EXISTS ClipboardEntries (
+    id INTEGER PRIMARY KEY,
     creation INTEGER PRIMARY KEY,
+    CREATE INDEX index_creation ON ClipboardEntries (creation)
 );
 
 CREATE TABLE IF NOT EXISTS FavoriteClipboardEntries (
     id INTEGER PRIMARY KEY,
     position INTEGER NOT NULL,
-	FOREIGN KEY (id) REFERENCES ClipboardEntries(creation) ON DELETE CASCADE,
+	FOREIGN KEY (id) REFERENCES ClipboardEntries(id) ON DELETE CASCADE,
     -- UNIQUE (position),
     CHECK (position >= 0)
 );
@@ -14,5 +16,5 @@ CREATE TABLE IF NOT EXISTS ClipboardContents (
     id INTEGER PRIMARY KEY,
     mime TEXT NOT NULL,
     content BLOB NOT NULL,
-	FOREIGN KEY (id) REFERENCES ClipboardEntries(creation) ON DELETE CASCADE,
+	FOREIGN KEY (id) REFERENCES ClipboardEntries(id) ON DELETE CASCADE
 );

--- a/migrations/20240723123147_init.sql
+++ b/migrations/20240723123147_init.sql
@@ -1,8 +1,9 @@
 CREATE TABLE IF NOT EXISTS ClipboardEntries (
     id INTEGER PRIMARY KEY,
-    creation INTEGER,
-    CREATE INDEX index_creation ON ClipboardEntries (creation)
+    creation INTEGER
 );
+
+CREATE INDEX IF NOT EXISTS index_creation ON ClipboardEntries (creation);
 
 CREATE TABLE IF NOT EXISTS ClipboardContents (
     id INTEGER PRIMARY KEY,

--- a/migrations/20240723123147_init.sql
+++ b/migrations/20240723123147_init.sql
@@ -6,9 +6,10 @@ CREATE TABLE IF NOT EXISTS ClipboardEntries (
 CREATE INDEX IF NOT EXISTS index_creation ON ClipboardEntries (creation);
 
 CREATE TABLE IF NOT EXISTS ClipboardContents (
-    id INTEGER PRIMARY KEY,
+    id INTEGER NOT NULL,
     mime TEXT NOT NULL,
     content BLOB NOT NULL,
+    PRIMARY KEY (id, mime),
 	FOREIGN KEY (id) REFERENCES ClipboardEntries(id) ON DELETE CASCADE
 );
 

--- a/migrations/20240723123147_init.sql
+++ b/migrations/20240723123147_init.sql
@@ -4,17 +4,17 @@ CREATE TABLE IF NOT EXISTS ClipboardEntries (
     CREATE INDEX index_creation ON ClipboardEntries (creation)
 );
 
+CREATE TABLE IF NOT EXISTS ClipboardContents (
+    id INTEGER PRIMARY KEY,
+    mime TEXT NOT NULL,
+    content BLOB NOT NULL,
+	FOREIGN KEY (id) REFERENCES ClipboardEntries(id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS FavoriteClipboardEntries (
     id INTEGER PRIMARY KEY,
     position INTEGER NOT NULL,
 	FOREIGN KEY (id) REFERENCES ClipboardEntries(id) ON DELETE CASCADE,
     -- UNIQUE (position),
     CHECK (position >= 0)
-);
-
-CREATE TABLE IF NOT EXISTS ClipboardContents (
-    id INTEGER PRIMARY KEY,
-    mime TEXT NOT NULL,
-    content BLOB NOT NULL,
-	FOREIGN KEY (id) REFERENCES ClipboardEntries(id) ON DELETE CASCADE
 );

--- a/migrations/20240723123147_init.sql
+++ b/migrations/20240723123147_init.sql
@@ -1,17 +1,18 @@
 CREATE TABLE IF NOT EXISTS ClipboardEntries (
     creation INTEGER PRIMARY KEY,
+);
+
+CREATE TABLE IF NOT EXISTS FavoriteClipboardEntries (
+    id INTEGER PRIMARY KEY,
+    position INTEGER NOT NULL,
+	FOREIGN KEY (id) REFERENCES ClipboardEntries(creation) ON DELETE CASCADE,
+    -- UNIQUE (position),
+    CHECK (position >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS ClipboardContents (
+    id INTEGER PRIMARY KEY,
     mime TEXT NOT NULL,
     content BLOB NOT NULL,
-    metadataMime TEXT,
-    metadata TEXT,
-    CHECK (
-        (
-            metadataMime IS NULL
-            AND metadata IS NULL
-        )
-        OR (
-            metadataMime IS NOT NULL
-            AND metadata IS NOT NULL
-        )
-    )
+	FOREIGN KEY (id) REFERENCES ClipboardEntries(creation) ON DELETE CASCADE,
 );

--- a/migrations/20240723123147_init.sql
+++ b/migrations/20240723123147_init.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS ClipboardEntries (
     id INTEGER PRIMARY KEY,
-    creation INTEGER PRIMARY KEY,
+    creation INTEGER,
     CREATE INDEX index_creation ON ClipboardEntries (creation)
 );
 

--- a/migrations/20240929151638_favorite.sql
+++ b/migrations/20240929151638_favorite.sql
@@ -1,7 +1,0 @@
-CREATE TABLE IF NOT EXISTS FavoriteClipboardEntries (
-    id INTEGER PRIMARY KEY,
-    position INTEGER NOT NULL,
-	FOREIGN KEY (id) REFERENCES ClipboardEntries(creation) ON DELETE CASCADE,
-    -- UNIQUE (position),
-    CHECK (position >= 0)
-);

--- a/res/config_schema.json
+++ b/res/config_schema.json
@@ -42,6 +42,13 @@
       "type": "integer",
       "format": "uint32",
       "minimum": 1.0
+    },
+    "preferred_mime_types": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "X_CONFIGURATOR_SOURCE_HOME_PATH": ".config/cosmic/io.github.wiiznokes.cosmic-ext-applet-clipboard-manager/v3",

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,7 @@ use futures::executor::block_on;
 use futures::StreamExt;
 
 use crate::config::{Config, PRIVATE_MODE};
-use crate::db::{self, DbMessage, DbTrait, EntryTrait};
+use crate::db::{DbMessage, DbTrait, EntryTrait};
 use crate::message::{AppMsg, ConfigMsg};
 use crate::navigation::EventMsg;
 use crate::utils::task_message;

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -47,7 +47,7 @@ pub fn sub() -> impl Stream<Item = ClipboardMessage> {
                         // 1.the main one
                         // optional 2. metadata
                         let mime_type_filter = |mut mime_types: HashSet<String>| {
-                            debug!("mime type {:?}", mime_types);
+                            info!("mime type {:#?}", mime_types);
 
                             let mut request = Vec::new();
 
@@ -141,7 +141,7 @@ pub fn sub() -> impl Stream<Item = ClipboardMessage> {
 
                                 let data = Entry::new_now(mime_type, contents, metadata, false);
 
-                                info!("sending data to database: {:?}", data);
+                                debug!("sending data to database: {:?}", data);
                                 output.send(ClipboardMessage::Data(data)).await.unwrap();
                             }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     io::Read,
     sync::atomic::{self},
 };
@@ -12,16 +12,11 @@ use wl_clipboard_rs::{
     paste_watch,
 };
 
-use crate::{config::PRIVATE_MODE, db::{EntryTrait, MimeDataMap}};
+use crate::{
+    config::PRIVATE_MODE,
+    db::{EntryTrait, MimeDataMap},
+};
 use os_pipe::PipeReader;
-
-// prefer popular formats
-// orderer by priority
-const IMAGE_MIME_TYPES: [&str; 3] = ["image/png", "image/jpeg", "image/ico"];
-
-// prefer popular formats
-// orderer by priority
-const TEXT_MIME_TYPES: [&str; 3] = ["text/plain;charset=utf-8", "UTF8_STRING", "text/plain"];
 
 #[derive(Debug, Clone)]
 pub enum ClipboardMessage {
@@ -117,9 +112,9 @@ pub fn sub() -> impl Stream<Item = ClipboardMessage> {
 pub fn copy<Entry: EntryTrait>(data: Entry) -> Result<(), copy::Error> {
     debug!("copy {:?}", data);
 
-    let mut sources = Vec::with_capacity(data.content().len());
+    let mut sources = Vec::with_capacity(data.raw_content().len());
 
-    for (mime, content) in data.content() {
+    for (mime, content) in data.into_raw_content() {
         let source = MimeSource {
             source: copy::Source::Bytes(content.into_boxed_slice()),
             mime_type: copy::MimeType::Specific(mime),

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,10 @@ pub struct Config {
     /// Reset the database at each login
     pub unique_session: bool,
     pub maximum_entries_by_page: NonZeroU32,
+    pub preferred_mime_types: Vec<String>,
 }
+
+pub static PRIVATE_MODE: AtomicBool = AtomicBool::new(false);
 
 impl Config {
     pub fn maximum_entries_lifetime(&self) -> Option<Duration> {
@@ -52,11 +55,10 @@ impl Default for Config {
             horizontal: false,
             unique_session: false,
             maximum_entries_by_page: NonZero::new(50).unwrap(),
+            preferred_mime_types: Vec::new(),
         }
     }
 }
-
-pub static PRIVATE_MODE: AtomicBool = AtomicBool::new(false);
 
 pub fn sub() -> Subscription<AppMsg> {
     struct ConfigSubscription;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -196,7 +196,16 @@ pub trait DbTrait: Sized {
 
     fn get_from_id(&self, id: EntryId) -> Option<&Self::Entry>;
 
-    fn iter(&self) -> Box<dyn Iterator<Item = &'_ Self::Entry> + '_>;
+    fn iter(&self) -> impl Iterator<Item = &'_ Self::Entry>;
+
+    fn search_iter(&self) -> impl Iterator<Item = &'_ Self::Entry>;
+
+    fn either_iter(
+        &self,
+    ) -> itertools::Either<
+        impl Iterator<Item = &'_ Self::Entry>,
+        impl Iterator<Item = &'_ Self::Entry>,
+    >;
 
     fn len(&self) -> usize;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -65,14 +65,15 @@ impl Debug for Content<'_> {
 
 /// More we have mime types here, Less we spend time in the [`EntryTrait::preferred_content`] function.
 const PRIV_MIME_TYPES_SIMPLE: &[&str] = &[
+    "image/png",
+    "image/jpg",
+    "image/jpeg",
+    "image/bmp",
     "text/plain;charset=utf-8",
     "text/plain",
     "STRING",
     "UTF8_STRING",
     "TEXT",
-    "image/png",
-    "image/jpg",
-    "image/jpeg",
 ];
 const PRIV_MIME_TYPES_REGEX_STR: &[&str] = &["text/plain*", "text/*", "image/*"];
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,3 @@
-use futures::future::BoxFuture;
 use std::{collections::HashMap, fmt::Debug, path::Path};
 
 use anyhow::{bail, Result};
@@ -7,8 +6,8 @@ use chrono::Utc;
 
 use crate::config::Config;
 
-// #[cfg(test)]
-// pub mod test;
+#[cfg(test)]
+pub mod test;
 
 mod sqlite_db;
 pub use sqlite_db::DbSqlite;
@@ -107,7 +106,9 @@ pub trait DbTrait: Sized {
 
     async fn reload(&mut self) -> Result<()>;
 
-    fn insert<'a: 'b, 'b>(&'a mut self, data: MimeDataMap) -> BoxFuture<'b, Result<()>>;
+    async fn insert(&mut self, data: MimeDataMap) -> Result<()>;
+
+    async fn insert_with_time(&mut self, data: MimeDataMap, time: i64) -> Result<()>;
 
     async fn delete(&mut self, data: EntryId) -> Result<()>;
 
@@ -116,8 +117,6 @@ pub trait DbTrait: Sized {
     async fn add_favorite(&mut self, entry: EntryId, index: Option<usize>) -> Result<()>;
 
     async fn remove_favorite(&mut self, entry: EntryId) -> Result<()>;
-
-    fn favorite_len(&self) -> usize;
 
     fn search(&mut self);
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,4 @@
+use alive_lock_file::LockResult;
 use derivative::Derivative;
 use futures::{future::BoxFuture, FutureExt};
 use sqlx::{migrate::MigrateDatabase, prelude::*, sqlite::SqliteRow, Sqlite, SqliteConnection};
@@ -22,103 +23,16 @@ use crate::{
     utils::{self},
 };
 
-#[cfg(test)]
-pub mod test;
+// #[cfg(test)]
+// pub mod test;
 
-type TimeId = i64;
+mod sqlite_db;
 
-const DB_VERSION: &str = "5";
-const DB_PATH: &str = constcat::concat!(APPID, "-db-", DB_VERSION, ".sqlite");
 
-#[derive(Clone, Eq, Derivative)]
-pub struct Entry {
-    pub creation: TimeId,
-    // todo: lazelly load image in memory, since we can't search them anyways
-    /// (Mime, Content)
-    pub content: HashMap<String, Vec<u8>>,
-    pub is_favorite: bool,
+fn now() -> i64 {
+    Utc::now().timestamp_millis()
 }
 
-impl Hash for Entry {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        for e in self.content.values() {
-            e.hash(state);
-        }
-    }
-}
-
-impl PartialEq for Entry {
-    fn eq(&self, other: &Self) -> bool {
-        self.content == other.content
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct EntryMetadata {
-    pub mime: String,
-    pub value: String,
-}
-
-impl Entry {
-    fn get_hash(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    pub fn new(
-        creation: i64,
-        content: HashMap<String, Vec<u8>>,
-        is_favorite: bool,
-    ) -> Self {
-        Self {
-            creation,
-            content,
-            is_favorite,
-        }
-    }
-
-    pub fn new_now(
-        content: HashMap<String, Vec<u8>>,
-        is_favorite: bool,
-    ) -> Self {
-        Self::new(
-            Utc::now().timestamp_millis(),
-            content,
-            is_favorite,
-        )
-    }
-
-    /// SELECT creation, mime, content, metadataMime, metadata
-    fn from_row(row: &SqliteRow, favorites: &Favorites) -> Result<Self> {
-        let id = row.get("creation");
-        let is_fav = favorites.contains(&id);
-
-        Ok(Entry::new(
-            id,
-            row.get("mime"),
-            row.get("content"),
-            row.try_get("metadataMime")
-                .ok()
-                .map(|metadata_mime| EntryMetadata {
-                    mime: metadata_mime,
-                    value: row.get("metadata"),
-                }),
-            is_fav,
-        ))
-    }
-}
-
-impl Debug for Entry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Data")
-            .field("creation", &self.creation)
-            .field("mime", &self.mime)
-            .field("content", &self.get_content())
-            .field("metadata", &self.metadata)
-            .finish()
-    }
-}
 
 pub enum Content<'a> {
     Text(&'a str),
@@ -136,8 +50,33 @@ impl Debug for Content<'_> {
     }
 }
 
-impl Entry {
-    pub fn get_content(&self) -> Result<Content<'_>> {
+
+
+// currently best effort
+fn find_alt(html: &str) -> Option<&str> {
+    const DEB: &str = "alt=\"";
+
+    if let Some(pos) = html.find(DEB) {
+        const OFFSET: usize = DEB.as_bytes().len();
+
+        if let Some(pos_end) = html[pos + OFFSET..].find('"') {
+            return Some(&html[pos + OFFSET..pos + pos_end + OFFSET]);
+        }
+    }
+
+    None
+}
+
+
+
+trait EntryTrait {
+
+    fn is_favorite(&self) -> bool;
+
+    fn content(&self) -> HashMap<String, Vec<u8>>;
+
+
+     fn get_content(&self) -> Result<Content<'_>> {
         if self.mime == "text/uri-list" {
             let text = if let Some(metadata) = &self.metadata {
                 &metadata.value
@@ -180,577 +119,46 @@ impl Entry {
 
         None
     }
+
 }
 
-// currently best effort
-fn find_alt(html: &str) -> Option<&str> {
-    const DEB: &str = "alt=\"";
+trait DbTrait: Sized {
 
-    if let Some(pos) = html.find(DEB) {
-        const OFFSET: usize = DEB.as_bytes().len();
+    type Entry: EntryTrait + Debug;
 
-        if let Some(pos_end) = html[pos + OFFSET..].find('"') {
-            return Some(&html[pos + OFFSET..pos + pos_end + OFFSET]);
-        }
-    }
+    async fn new(config: &Config) -> Result<Self>;
 
-    None
-}
+    async fn with_path(config: &Config, db_dir: &Path) -> Result<Self>;
 
-pub struct Db {
-    conn: SqliteConnection,
-    hashs: HashMap<u64, TimeId>,
-    state: BTreeMap<TimeId, Entry>,
-    filtered: Vec<(TimeId, Vec<u32>)>,
-    query: String,
-    needle: Option<Atom>,
-    matcher: Matcher,
-    data_version: i64,
-    favorites: Favorites,
-}
+    async fn reload(&mut self) -> Result<()>;
 
-#[derive(Default)]
-struct Favorites {
-    favorites: Vec<TimeId>,
-    favorites_hash_set: HashSet<TimeId>,
-}
+    fn insert<'a: 'b, 'b>(&'a mut self, data: Self::Entry) -> BoxFuture<'b, Result<()>>;
 
-impl Favorites {
-    fn contains(&self, id: &TimeId) -> bool {
-        self.favorites_hash_set.contains(id)
-    }
-    fn clear(&mut self) {
-        self.favorites.clear();
-        self.favorites_hash_set.clear();
-    }
+    async fn delete(&mut self, data: &Self::Entry) -> Result<()>;
 
-    fn insert_at(&mut self, id: TimeId, pos: Option<usize>) {
-        match pos {
-            Some(pos) => self.favorites.insert(pos, id),
-            None => self.favorites.push(id),
-        }
-        self.favorites_hash_set.insert(id);
-    }
+    async fn clear(&mut self) -> Result<()>;
 
-    fn remove(&mut self, id: &TimeId) -> Option<usize> {
-        self.favorites_hash_set.remove(id);
-        self.favorites.iter().position(|e| e == id).inspect(|i| {
-            self.favorites.remove(*i);
-        })
-    }
+    async fn add_favorite(&mut self, entry: &Self::Entry, index: Option<usize>) -> Result<()>;
 
-    fn fav(&self) -> &Vec<TimeId> {
-        &self.favorites
-    }
+    async fn remove_favorite(&mut self, entry: &Self::Entry) -> Result<()>;
 
-    fn change(&mut self, prev: &TimeId, new: TimeId) {
-        let pos = self.favorites.iter().position(|e| e == prev).unwrap();
-        self.favorites[pos] = new;
-        self.favorites_hash_set.remove(prev);
-        self.favorites_hash_set.insert(new);
-    }
-}
+    fn favorite_len(&self) -> usize;
 
-impl Db {
-    pub async fn new(config: &Config) -> Result<Self> {
-        let directories = directories::ProjectDirs::from(QUALIFIER, ORG, APP).unwrap();
+    fn search(&mut self);
 
-        std::fs::create_dir_all(directories.cache_dir())?;
+    fn set_query_and_search(&mut self, query: String);
 
-        Self::inner_new(config, directories.cache_dir()).await
-    }
+    fn query(&self) -> &str;
 
-    async fn inner_new(config: &Config, db_dir: &Path) -> Result<Self> {
-        let db_path = db_dir.join(DB_PATH);
+    fn get(&self, index: usize) -> Option<&Self::Entry>;
 
-        let db_path = db_path
-            .to_str()
-            .ok_or(anyhow!("can't convert path to str"))?;
+    fn iter(&self) -> impl Iterator<Item = &'_ Self::Entry>;
 
-        if !Sqlite::database_exists(db_path).await? {
-            info!("Creating database {}", db_path);
-            Sqlite::create_database(db_path).await?;
-        }
+    fn search_iter(&self) -> impl Iterator<Item = (&'_ Self::Entry, &'_ Vec<u32>)>;
 
-        let mut conn = SqliteConnection::connect(db_path).await?;
+    fn len(&self) -> usize;
 
-        let migration_path = db_dir.join("migrations");
-        std::fs::create_dir_all(&migration_path)?;
-        include_dir::include_dir!("migrations")
-            .extract(&migration_path)
-            .unwrap();
-
-        match sqlx::migrate::Migrator::new(migration_path).await {
-            Ok(migrator) => migrator,
-            Err(e) => {
-                warn!("migrator error {e}, fall back to relative path");
-                sqlx::migrate::Migrator::new(Path::new("./migrations")).await?
-            }
-        }
-        .run(&mut conn)
-        .await?;
-
-        if let Some(max_duration) = config.maximum_entries_lifetime() {
-            let now_millis = utils::now_millis();
-            let max_millis = max_duration.as_millis().try_into().unwrap_or(u64::MAX);
-
-            let query_delete_old_one = r#"
-                DELETE FROM ClipboardEntries
-                WHERE (? - creation) >= ? AND creation NOT IN(
-                    SELECT id
-                    FROM FavoriteClipboardEntries
-                );
-            "#;
-
-            sqlx::query(query_delete_old_one)
-                .bind(now_millis)
-                .bind(max_millis as i64)
-                .execute(&mut conn)
-                .await
-                .unwrap();
-        }
-
-        if let Some(max_number_of_entries) = &config.maximum_entries_number {
-            let query_delete_old_one = r#"
-                WITH MostRecentEntries AS (
-                    SELECT creation
-                    FROM ClipboardEntries
-                    ORDER BY creation DESC
-                    LIMIT ?
-                )
-                DELETE FROM ClipboardEntries
-                WHERE creation NOT IN (
-                    SELECT creation
-                    FROM MostRecentEntries
-                    FULL JOIN FavoriteClipboardEntries ON (creation = id));
-            "#;
-
-            sqlx::query(query_delete_old_one)
-                .bind(max_number_of_entries)
-                .execute(&mut conn)
-                .await
-                .unwrap();
-        }
-
-        let mut db = Db {
-            data_version: fetch_data_version(&mut conn).await?,
-            conn,
-            hashs: HashMap::default(),
-            state: BTreeMap::default(),
-            filtered: Vec::default(),
-            query: String::default(),
-            needle: None,
-            matcher: Matcher::new(nucleo::Config::DEFAULT),
-            favorites: Favorites::default(),
-        };
-
-        db.reload().await?;
-
-        Ok(db)
-    }
-
-    async fn reload(&mut self) -> Result<()> {
-        self.hashs.clear();
-        self.state.clear();
-        self.favorites.clear();
-
-        {
-            let query_load_favs = r#"
-                SELECT id, position
-                FROM FavoriteClipboardEntries
-            "#;
-
-            let rows = sqlx::query(query_load_favs)
-                .fetch_all(&mut self.conn)
-                .await?;
-
-            let mut rows = rows
-                .iter()
-                .map(|row| {
-                    let id: i64 = row.get("id");
-                    let index: i32 = row.get("position");
-                    (id, index as usize)
-                })
-                .collect::<Vec<_>>();
-
-            rows.sort_by(|e1, e2| e1.1.cmp(&e2.1));
-
-            debug_assert_eq!(rows.last().map(|e| e.1 + 1).unwrap_or(0), rows.len());
-
-            for (id, pos) in rows {
-                self.favorites.insert_at(id, Some(pos));
-            }
-        }
-
-        {
-            let query_load_table = r#"
-                SELECT creation, mime, content, metadataMime, metadata
-                FROM ClipboardEntries
-                JOIN ClipboardContents ON (id = creation)
-                GROUP BY
-            "#;
-
-            let rows = sqlx::query(query_load_table)
-                .fetch_all(&mut self.conn)
-                .await?;
-
-                sqlx::query(query_load_table)
-                    .fetch(executor)
-
-            for row in &rows {
-                let data = Entry::from_row(row, &self.favorites)?;
-
-                self.hashs.insert(data.get_hash(), data.creation);
-                self.state.insert(data.creation, data);
-            }
-        }
-
-        self.search();
-
-        Ok(())
-    }
-
-    async fn get_last_row(&mut self) -> Result<Option<Entry>> {
-        let query_get_last_row = r#"
-            SELECT creation, mime, content, metadataMime, metadata
-            FROM ClipboardEntries
-            ORDER BY creation DESC
-            LIMIT 1
-        "#;
-
-        let entry = sqlx::query(query_get_last_row)
-            .fetch_optional(&mut self.conn)
-            .await?
-            .map(|e| Entry::from_row(&e, &self.favorites).unwrap());
-
-        Ok(entry)
-    }
-
-    // the <= 200 condition, is to unsure we reuse the same timestamp
-    // of the first process that inserted the data.
-    pub fn insert<'a: 'b, 'b>(&'a mut self, mut data: Entry) -> BoxFuture<'b, Result<()>> {
-        async move {
-            // insert a new data, only if the last row is not the same AND was not created recently
-            let query_insert_if_not_exist = r#"
-                WITH last_row AS (
-                    SELECT creation, mime, content, metadataMime, metadata
-                    FROM ClipboardEntries
-                    ORDER BY creation DESC
-                    LIMIT 1
-                )
-                INSERT INTO ClipboardEntries (creation, mime, content, metadataMime, metadata)
-                SELECT $1, $2, $3, $4, $5
-                WHERE NOT EXISTS (
-                    SELECT 1
-                    FROM last_row AS lr
-                    WHERE lr.content = $3 AND ($6 - lr.creation) <= 1000
-                );
-            "#;
-
-            if let Err(e) = sqlx::query(query_insert_if_not_exist)
-                .bind(data.creation)
-                .bind(&data.mime)
-                .bind(&data.content)
-                .bind(data.metadata.as_ref().map(|m| &m.mime))
-                .bind(data.metadata.as_ref().map(|m| &m.value))
-                .bind(utils::now_millis())
-                .execute(&mut self.conn)
-                .await
-            {
-                if let sqlx::Error::Database(e) = &e {
-                    if e.is_unique_violation() {
-                        warn!("a different value with the same id was already inserted");
-                        data.creation += 1;
-                        return self.insert(data).await;
-                    }
-                }
-
-                return Err(e.into());
-            }
-
-            // safe to unwrap since we insert before
-            let last_row = self.get_last_row().await?.unwrap();
-
-            let new_id = last_row.creation;
-
-            let data_hash = data.get_hash();
-
-            if let Some(old_id) = self.hashs.remove(&data_hash) {
-                self.state.remove(&old_id);
-
-                if self.favorites.contains(&old_id) {
-                    data.is_favorite = true;
-                    let query_delete_old_id = r#"
-                        UPDATE FavoriteClipboardEntries
-                        SET id = $1
-                        WHERE id = $2;
-                    "#;
-
-                    sqlx::query(query_delete_old_id)
-                        .bind(new_id)
-                        .bind(old_id)
-                        .execute(&mut self.conn)
-                        .await?;
-
-                    self.favorites.change(&old_id, new_id);
-                } else {
-                    data.is_favorite = false;
-                }
-
-                // in case 2 same data were inserted in a short period
-                // we don't want to remove the old_id
-                if new_id != old_id {
-                    let query_delete_old_id = r#"
-                        DELETE FROM ClipboardEntries
-                        WHERE creation = ?;
-                    "#;
-
-                    sqlx::query(query_delete_old_id)
-                        .bind(old_id)
-                        .execute(&mut self.conn)
-                        .await?;
-                }
-            }
-
-            data.creation = new_id;
-
-            self.hashs.insert(data_hash, data.creation);
-            self.state.insert(data.creation, data);
-
-            self.search();
-            Ok(())
-        }
-        .boxed()
-    }
-
-    pub async fn delete(&mut self, data: &Entry) -> Result<()> {
-        let query = r#"
-            DELETE FROM ClipboardEntries
-            WHERE creation = ?;
-        "#;
-
-        sqlx::query(query)
-            .bind(data.creation)
-            .execute(&mut self.conn)
-            .await?;
-
-        self.hashs.remove(&data.get_hash());
-        self.state.remove(&data.creation);
-
-        if data.is_favorite {
-            self.favorites.remove(&data.creation);
-        }
-
-        self.search();
-        Ok(())
-    }
-
-    pub async fn clear(&mut self) -> Result<()> {
-        let query_delete = r#"
-            DELETE FROM ClipboardEntries
-            WHERE creation NOT IN(
-                SELECT id
-                FROM FavoriteClipboardEntries
-            );
-        "#;
-
-        sqlx::query(query_delete).execute(&mut self.conn).await?;
-
-        self.reload().await?;
-
-        Ok(())
-    }
-
-    pub async fn add_favorite(&mut self, entry: &Entry, index: Option<usize>) -> Result<()> {
-        debug_assert!(!self.favorites.fav().contains(&entry.creation));
-
-        self.favorites.insert_at(entry.creation, index);
-
-        if let Some(pos) = index {
-            let query = r#"
-                UPDATE FavoriteClipboardEntries
-                SET position = position + 1
-                WHERE position >= ?;
-            "#;
-            sqlx::query(query)
-                .bind(pos as i32)
-                .execute(&mut self.conn)
-                .await
-                .unwrap();
-        }
-
-        let index = index.unwrap_or(self.favorite_len() - 1);
-
-        {
-            let query = r#"
-                INSERT INTO FavoriteClipboardEntries (id, position)
-                VALUES ($1, $2);
-            "#;
-
-            sqlx::query(query)
-                .bind(entry.creation)
-                .bind(index as i32)
-                .execute(&mut self.conn)
-                .await?;
-        }
-
-        if let Some(e) = self.state.get_mut(&entry.creation) {
-            e.is_favorite = true;
-        }
-
-        Ok(())
-    }
-
-    pub async fn remove_favorite(&mut self, entry: &Entry) -> Result<()> {
-        debug_assert!(self.favorites.fav().contains(&entry.creation));
-
-        {
-            let query = r#"
-                DELETE FROM FavoriteClipboardEntries
-                WHERE id = ?;
-            "#;
-
-            sqlx::query(query)
-                .bind(entry.creation)
-                .execute(&mut self.conn)
-                .await?;
-        }
-
-        if let Some(pos) = self.favorites.remove(&entry.creation) {
-            let query = r#"
-                UPDATE FavoriteClipboardEntries
-                SET position = position - 1
-                WHERE position >= ?;
-            "#;
-            sqlx::query(query)
-                .bind(pos as i32)
-                .execute(&mut self.conn)
-                .await?;
-        }
-
-        if let Some(e) = self.state.get_mut(&entry.creation) {
-            e.is_favorite = false;
-        }
-        Ok(())
-    }
-
-    pub fn favorite_len(&self) -> usize {
-        self.favorites.favorites.len()
-    }
-
-    pub fn search(&mut self) {
-        if self.query.is_empty() {
-            self.filtered.clear();
-        } else if let Some(atom) = &self.needle {
-            self.filtered = Self::iter_inner(&self.state, &self.favorites)
-                .filter_map(|data| {
-                    data.get_searchable_text().and_then(|text| {
-                        let mut buf = Vec::new();
-
-                        let haystack = Utf32Str::new(text, &mut buf);
-
-                        let mut indices = Vec::new();
-
-                        let _res = atom.indices(haystack, &mut self.matcher, &mut indices);
-
-                        if !indices.is_empty() {
-                            Some((data.creation, indices))
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .collect::<Vec<_>>();
-        }
-    }
-
-    pub fn set_query_and_search(&mut self, query: String) {
-        if query.is_empty() {
-            self.needle.take();
-        } else {
-            let atom = Atom::new(
-                &query,
-                CaseMatching::Smart,
-                Normalization::Smart,
-                AtomKind::Substring,
-                true,
-            );
-
-            self.needle.replace(atom);
-        }
-
-        self.query = query;
-
-        self.search();
-    }
-
-    pub fn query(&self) -> &str {
-        &self.query
-    }
-
-    pub fn get(&self, index: usize) -> Option<&Entry> {
-        if self.query.is_empty() {
-            self.iter().nth(index)
-        } else {
-            self.filtered
-                .get(index)
-                .map(|(id, _indices)| &self.state[id])
-        }
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &'_ Entry> {
-        debug_assert!(self.query.is_empty());
-        Self::iter_inner(&self.state, &self.favorites)
-    }
-
-    fn iter_inner<'a>(
-        state: &'a BTreeMap<TimeId, Entry>,
-        favorites: &'a Favorites,
-    ) -> impl Iterator<Item = &'a Entry> + 'a {
-        favorites
-            .fav()
-            .iter()
-            .filter_map(|id| state.get(id))
-            .chain(state.values().filter(|e| !e.is_favorite).rev())
-    }
-
-    pub fn search_iter(&self) -> impl Iterator<Item = (&'_ Entry, &'_ Vec<u32>)> {
-        debug_assert!(!self.query.is_empty());
-
-        self.filtered
-            .iter()
-            .map(|(id, indices)| (&self.state[id], indices))
-    }
-
-    pub fn len(&self) -> usize {
-        if self.query.is_empty() {
-            self.state.len()
-        } else {
-            self.filtered.len()
-        }
-    }
-
-    pub async fn handle_message(&mut self, _message: DbMessage) -> Result<()> {
-        let data_version = fetch_data_version(&mut self.conn).await?;
-
-        if self.data_version != data_version {
-            self.reload().await?;
-        }
-
-        self.data_version = data_version;
-
-        Ok(())
-    }
-}
-
-/// https://www.sqlite.org/pragma.html#pragma_data_version
-async fn fetch_data_version(conn: &mut SqliteConnection) -> Result<i64> {
-    let data_version: i64 = sqlx::query("PRAGMA data_version")
-        .fetch_one(conn)
-        .await?
-        .get("data_version");
-
-    Ok(data_version)
+    async fn handle_message(&mut self, message: DbMessage) -> Result<()>;
 }
 
 #[derive(Clone, Debug)]

--- a/src/db/sqlite_db.rs
+++ b/src/db/sqlite_db.rs
@@ -27,7 +27,6 @@ use super::{DbMessage, DbTrait, EntryTrait};
 
 
 type Time = i64;
-type EntryId = i64;
 
 const DB_VERSION: &str = "5";
 const DB_PATH: &str = constcat::concat!(APPID, "-db-", DB_VERSION, ".sqlite");
@@ -86,7 +85,6 @@ pub struct Entry {
     // todo: lazelly load image in memory, since we can't search them anyways
     /// (Mime, Content)
     pub content: HashMap<String, Vec<u8>>,
-    pub is_favorite: bool,
 }
 
 impl Hash for Entry {
@@ -177,7 +175,7 @@ pub struct EntryMetadata {
 
 
 
-pub struct Db {
+pub struct DbSqlite {
     conn: SqliteConnection,
     /// Hash -> Id
     hashs: HashMap<u64, EntryId>,
@@ -194,7 +192,7 @@ pub struct Db {
 }
 
 
-impl DbTrait for Db {
+impl DbTrait for DbSqlite {
     type Entry = Entry;
 
      async fn new(config: &Config) -> Result<Self> {
@@ -304,7 +302,7 @@ impl DbTrait for Db {
          
         }
 
-        let mut db = Db {
+        let mut db = DbSqlite {
             data_version: fetch_data_version(&mut conn).await?,
             conn,
             hashs: HashMap::default(),
@@ -703,7 +701,7 @@ impl DbTrait for Db {
     }
 }
 
-impl Db {
+impl DbSqlite {
     
     fn iter_inner<'a>(
         state: &'a BTreeMap<Time, Entry>,

--- a/src/db/sqlite_db.rs
+++ b/src/db/sqlite_db.rs
@@ -163,7 +163,7 @@ impl Debug for Entry {
         f.debug_struct("Data")
             .field("id", &self.id)
             .field("creation", &self.creation)
-            .field("content", &self.viewable_content())
+            .field("content", &self.preferred_content(&[]))
             .finish()
     }
 }

--- a/src/db/sqlite_db.rs
+++ b/src/db/sqlite_db.rs
@@ -291,10 +291,6 @@ impl DbTrait for DbSqlite {
 
         db.reload().await?;
 
-        dbg!(&db.hashs);
-        dbg!(&db.times);
-        dbg!(&db.entries);
-
         Ok(db)
     }
 
@@ -627,7 +623,6 @@ impl DbTrait for DbSqlite {
                     }
                 })
                 .collect::<Vec<_>>();
-            dbg!(&self.filtered);
         }
     }
 

--- a/src/db/sqlite_db.rs
+++ b/src/db/sqlite_db.rs
@@ -1,0 +1,728 @@
+use alive_lock_file::LockResult;
+use derivative::Derivative;
+use futures::{future::BoxFuture, FutureExt};
+use sqlx::{migrate::MigrateDatabase, prelude::*, sqlite::SqliteRow, Sqlite, SqliteConnection};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::Debug,
+    hash::{DefaultHasher, Hash, Hasher},
+    path::Path,
+};
+
+use anyhow::{anyhow, bail, Result};
+use nucleo::{
+    pattern::{Atom, AtomKind, CaseMatching, Normalization},
+    Matcher, Utf32Str,
+};
+
+use chrono::Utc;
+
+use crate::{
+    app::{APP, APPID, ORG, QUALIFIER},
+    config::Config,
+    utils::{self},
+};
+
+use super::{DbMessage, DbTrait, EntryTrait};
+
+
+type Time = i64;
+type EntryId = i64;
+
+const DB_VERSION: &str = "5";
+const DB_PATH: &str = constcat::concat!(APPID, "-db-", DB_VERSION, ".sqlite");
+
+const LOCK_FILE: &str = constcat::concat!(APPID, "-db", ".lock");
+
+
+#[derive(Default)]
+struct Favorites {
+    favorites: Vec<EntryId>,
+    favorites_hash_set: HashSet<EntryId>,
+}
+
+impl Favorites {
+    fn contains(&self, id: &EntryId) -> bool {
+        self.favorites_hash_set.contains(id)
+    }
+    fn clear(&mut self) {
+        self.favorites.clear();
+        self.favorites_hash_set.clear();
+    }
+
+    fn insert_at(&mut self, id: EntryId, pos: Option<usize>) {
+        match pos {
+            Some(pos) => self.favorites.insert(pos, id),
+            None => self.favorites.push(id),
+        }
+        self.favorites_hash_set.insert(id);
+    }
+
+    fn remove(&mut self, id: &EntryId) -> Option<usize> {
+        self.favorites_hash_set.remove(id);
+        self.favorites.iter().position(|e| e == id).inspect(|i| {
+            self.favorites.remove(*i);
+        })
+    }
+
+    fn fav(&self) -> &Vec<EntryId> {
+        &self.favorites
+    }
+
+    fn change(&mut self, prev: &EntryId, new: EntryId) {
+        let pos = self.favorites.iter().position(|e| e == prev).unwrap();
+        self.favorites[pos] = new;
+        self.favorites_hash_set.remove(prev);
+        self.favorites_hash_set.insert(new);
+    }
+}
+
+
+
+#[derive(Clone, Eq, Derivative)]
+pub struct Entry {
+    pub id: EntryId,
+    pub creation: Time,
+    // todo: lazelly load image in memory, since we can't search them anyways
+    /// (Mime, Content)
+    pub content: HashMap<String, Vec<u8>>,
+    pub is_favorite: bool,
+}
+
+impl Hash for Entry {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for e in self.content.values() {
+            e.hash(state);
+        }
+    }
+}
+
+impl PartialEq for Entry {
+    fn eq(&self, other: &Self) -> bool {
+        self.content == other.content
+    }
+}
+
+impl EntryTrait for Entry {
+    fn is_favorite(&self) -> bool {
+        todo!()
+    }
+
+    fn content(&self) -> HashMap<String, Vec<u8>> {
+        todo!()
+    }
+}
+
+impl Entry {
+    fn get_hash(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    pub fn new(id: i64, creation: i64, content: HashMap<String, Vec<u8>>, is_favorite: bool) -> Self {
+        Self {
+            creation,
+            content,
+            is_favorite,
+            id,
+        }
+    }
+
+   
+}
+
+impl Debug for Entry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Data")
+        .field("id", &self.id)
+            .field("creation", &self.creation)
+            .field("content", &self.get_content())
+            .finish()
+    }
+}
+
+
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EntryMetadata {
+    pub mime: String,
+    pub value: String,
+}
+
+// impl Entry {
+    
+
+//     /// SELECT creation, mime, content, metadataMime, metadata
+//     fn from_row(row: &SqliteRow, favorites: &Favorites) -> Result<Self> {
+//         let id = row.get("creation");
+//         let is_fav = favorites.contains(&id);
+
+//         Ok(Entry::new(
+//             id,
+//             row.get("mime"),
+//             row.get("content"),
+//             row.try_get("metadataMime")
+//                 .ok()
+//                 .map(|metadata_mime| EntryMetadata {
+//                     mime: metadata_mime,
+//                     value: row.get("metadata"),
+//                 }),
+//             is_fav,
+//         ))
+//     }
+// }
+
+
+
+
+
+pub struct Db {
+    conn: SqliteConnection,
+    /// Hash -> Id
+    hashs: HashMap<u64, EntryId>,
+    /// time -> Id
+    times: BTreeMap<Time, EntryId>,
+    /// Id -> Entry
+    entries: HashMap<EntryId, Entry>,
+    filtered: Vec<(EntryId, Vec<u32>)>,
+    query: String,
+    needle: Option<Atom>,
+    matcher: Matcher,
+    data_version: i64,
+    favorites: Favorites,
+}
+
+
+impl DbTrait for Db {
+    type Entry = Entry;
+
+     async fn new(config: &Config) -> Result<Self> {
+        let directories = directories::ProjectDirs::from(QUALIFIER, ORG, APP).unwrap();
+
+        std::fs::create_dir_all(directories.cache_dir())?;
+
+        Self::with_path(config, directories.cache_dir()).await
+    }
+
+    async fn with_path(config: &Config, db_dir: &Path) -> Result<Self> {
+
+        if let Err(e) = alive_lock_file::remove_lock(LOCK_FILE) {
+            error!("can't remove lock {e}");
+        }
+        
+
+        let db_path = db_dir.join(DB_PATH);
+
+        let db_path = db_path
+            .to_str()
+            .ok_or(anyhow!("can't convert path to str"))?;
+
+        if !Sqlite::database_exists(db_path).await? {
+            info!("Creating database {}", db_path);
+            Sqlite::create_database(db_path).await?;
+        }
+
+        let mut conn = SqliteConnection::connect(db_path).await?;
+
+        let migration_path = db_dir.join("migrations");
+        std::fs::create_dir_all(&migration_path)?;
+        include_dir::include_dir!("migrations")
+            .extract(&migration_path)
+            .unwrap();
+
+        match sqlx::migrate::Migrator::new(migration_path).await {
+            Ok(migrator) => migrator,
+            Err(e) => {
+                warn!("migrator error {e}, fall back to relative path");
+                sqlx::migrate::Migrator::new(Path::new("./migrations")).await?
+            }
+        }
+        .run(&mut conn)
+        .await?;
+
+        if let Some(max_duration) = config.maximum_entries_lifetime() {
+            let now_millis = utils::now_millis();
+            let max_millis = max_duration.as_millis().try_into().unwrap_or(u64::MAX);
+
+            let query_delete_old_one = r#"
+                DELETE FROM ClipboardEntries
+                WHERE (? - creation) >= ? AND id NOT IN(
+                    SELECT id
+                    FROM FavoriteClipboardEntries
+                );
+            "#;
+
+            sqlx::query(query_delete_old_one)
+                .bind(now_millis)
+                .bind(max_millis as i64)
+                .execute(&mut conn)
+                .await
+                .unwrap();
+        }
+
+        if let Some(max_number_of_entries) = &config.maximum_entries_number {
+
+            let query_get_most_older = r#"
+                SELECT creation
+                FROM ClipboardEntries
+                ORDER BY creation DESC
+                LIMIT 1 OFFSET ?
+            "#;
+
+            match sqlx::query(query_get_most_older)
+                .bind(max_number_of_entries)
+                .fetch_optional(&mut conn)
+                .await
+                .unwrap() {
+
+
+                    Some(r) => {
+                        let creation: Time = r.get("creation");
+
+                        let query_delete_old_one = r#"
+                
+                            DELETE FROM ClipboardEntries
+                            WHERE creation < ? AND id NOT IN (
+                                SELECT id
+                                FROM FavoriteClipboardEntries);
+                            "#;
+
+                        sqlx::query(query_delete_old_one)
+                            .bind(creation)
+                            .execute(&mut conn)
+                            .await
+                            .unwrap();
+
+                                },
+                                None => {
+                                    // nothing to do
+                                },
+                            }
+
+            
+         
+        }
+
+        let mut db = Db {
+            data_version: fetch_data_version(&mut conn).await?,
+            conn,
+            hashs: HashMap::default(),
+            times: BTreeMap::default(),
+            entries: HashMap::default(),
+            filtered: Vec::default(),
+            query: String::default(),
+            needle: None,
+            matcher: Matcher::new(nucleo::Config::DEFAULT),
+            favorites: Favorites::default(),
+        };
+
+        db.reload().await?;
+
+        Ok(db)
+    }
+
+    async fn reload(&mut self) -> Result<()> {
+        self.hashs.clear();
+        self.entries.clear();
+        self.times.clear();
+        self.favorites.clear();
+
+        {
+            let query_load_favs = r#"
+                SELECT id, position
+                FROM FavoriteClipboardEntries
+            "#;
+
+            let rows = sqlx::query(query_load_favs)
+                .fetch_all(&mut self.conn)
+                .await?;
+
+            let mut rows = rows
+                .iter()
+                .map(|row| {
+                    let id: i64 = row.get("id");
+                    let index: i32 = row.get("position");
+                    (id, index as usize)
+                })
+                .collect::<Vec<_>>();
+
+            rows.sort_by(|e1, e2| e1.1.cmp(&e2.1));
+
+            debug_assert_eq!(rows.last().map(|e| e.1 + 1).unwrap_or(0), rows.len());
+
+            for (id, pos) in rows {
+                self.favorites.insert_at(id, Some(pos));
+            }
+        }
+
+        {
+            let query_load_table = r#"
+                SELECT creation, mime, content, metadataMime, metadata
+                FROM ClipboardEntries
+                JOIN ClipboardContents ON (id = creation)
+                GROUP BY
+            "#;
+
+            let rows = sqlx::query(query_load_table)
+                .fetch_all(&mut self.conn)
+                .await?;
+
+                sqlx::query(query_load_table)
+                    .fetch(executor)
+
+            for row in &rows {
+                let data = Entry::from_row(row, &self.favorites)?;
+
+                self.hashs.insert(data.get_hash(), data.creation);
+                self.state.insert(data.creation, data);
+            }
+        }
+
+        self.search();
+
+        Ok(())
+    }
+
+    
+
+    // the <= 200 condition, is to unsure we reuse the same timestamp
+    // of the first process that inserted the data.
+     fn insert<'a: 'b, 'b>(&'a mut self, mut data: Entry) -> BoxFuture<'b, Result<()>> {
+        async move {
+
+            match alive_lock_file::try_lock(LOCK_FILE)? {
+                LockResult::Success => {}
+                LockResult::AlreadyLocked => {
+                    info!("db already locked");
+                    return Ok(());
+                }
+            }
+            
+            // insert a new data, only if the last row is not the same AND was not created recently
+            let query_insert_if_not_exist = r#"
+                WITH last_row AS (
+                    SELECT creation, mime, content, metadataMime, metadata
+                    FROM ClipboardEntries
+                    ORDER BY creation DESC
+                    LIMIT 1
+                )
+                INSERT INTO ClipboardEntries (creation, mime, content, metadataMime, metadata)
+                SELECT $1, $2, $3, $4, $5
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM last_row AS lr
+                    WHERE lr.content = $3 AND ($6 - lr.creation) <= 1000
+                );
+            "#;
+
+            if let Err(e) = sqlx::query(query_insert_if_not_exist)
+                .bind(data.creation)
+                .bind(&data.mime)
+                .bind(&data.content)
+                .bind(data.metadata.as_ref().map(|m| &m.mime))
+                .bind(data.metadata.as_ref().map(|m| &m.value))
+                .bind(utils::now_millis())
+                .execute(&mut self.conn)
+                .await
+            {
+                if let sqlx::Error::Database(e) = &e {
+                    if e.is_unique_violation() {
+                        warn!("a different value with the same id was already inserted");
+                        data.creation += 1;
+                        return self.insert(data).await;
+                    }
+                }
+
+                return Err(e.into());
+            }
+
+            // safe to unwrap since we insert before
+            let last_row = self.get_last_row().await?.unwrap();
+
+            let new_id = last_row.creation;
+
+            let data_hash = data.get_hash();
+
+            if let Some(old_id) = self.hashs.remove(&data_hash) {
+                self.state.remove(&old_id);
+
+                if self.favorites.contains(&old_id) {
+                    data.is_favorite = true;
+                    let query_delete_old_id = r#"
+                        UPDATE FavoriteClipboardEntries
+                        SET id = $1
+                        WHERE id = $2;
+                    "#;
+
+                    sqlx::query(query_delete_old_id)
+                        .bind(new_id)
+                        .bind(old_id)
+                        .execute(&mut self.conn)
+                        .await?;
+
+                    self.favorites.change(&old_id, new_id);
+                } else {
+                    data.is_favorite = false;
+                }
+
+                // in case 2 same data were inserted in a short period
+                // we don't want to remove the old_id
+                if new_id != old_id {
+                    let query_delete_old_id = r#"
+                        DELETE FROM ClipboardEntries
+                        WHERE creation = ?;
+                    "#;
+
+                    sqlx::query(query_delete_old_id)
+                        .bind(old_id)
+                        .execute(&mut self.conn)
+                        .await?;
+                }
+            }
+
+            data.creation = new_id;
+
+            self.hashs.insert(data_hash, data.creation);
+            self.state.insert(data.creation, data);
+
+            self.search();
+            Ok(())
+        }
+        .boxed()
+    }
+
+     async fn delete(&mut self, data: &Entry) -> Result<()> {
+        let query = r#"
+            DELETE FROM ClipboardEntries
+            WHERE creation = ?;
+        "#;
+
+        sqlx::query(query)
+            .bind(data.creation)
+            .execute(&mut self.conn)
+            .await?;
+
+        self.hashs.remove(&data.get_hash());
+        self.state.remove(&data.creation);
+
+        if data.is_favorite {
+            self.favorites.remove(&data.creation);
+        }
+
+        self.search();
+        Ok(())
+    }
+
+     async fn clear(&mut self) -> Result<()> {
+        let query_delete = r#"
+            DELETE FROM ClipboardEntries
+            WHERE creation NOT IN(
+                SELECT id
+                FROM FavoriteClipboardEntries
+            );
+        "#;
+
+        sqlx::query(query_delete).execute(&mut self.conn).await?;
+
+        self.reload().await?;
+
+        Ok(())
+    }
+
+     async fn add_favorite(&mut self, entry: &Entry, index: Option<usize>) -> Result<()> {
+        debug_assert!(!self.favorites.fav().contains(&entry.creation));
+
+        self.favorites.insert_at(entry.creation, index);
+
+        if let Some(pos) = index {
+            let query = r#"
+                UPDATE FavoriteClipboardEntries
+                SET position = position + 1
+                WHERE position >= ?;
+            "#;
+            sqlx::query(query)
+                .bind(pos as i32)
+                .execute(&mut self.conn)
+                .await
+                .unwrap();
+        }
+
+        let index = index.unwrap_or(self.favorite_len() - 1);
+
+        {
+            let query = r#"
+                INSERT INTO FavoriteClipboardEntries (id, position)
+                VALUES ($1, $2);
+            "#;
+
+            sqlx::query(query)
+                .bind(entry.creation)
+                .bind(index as i32)
+                .execute(&mut self.conn)
+                .await?;
+        }
+
+        if let Some(e) = self.state.get_mut(&entry.creation) {
+            e.is_favorite = true;
+        }
+
+        Ok(())
+    }
+
+     async fn remove_favorite(&mut self, entry: &Entry) -> Result<()> {
+        debug_assert!(self.favorites.fav().contains(&entry.creation));
+
+        {
+            let query = r#"
+                DELETE FROM FavoriteClipboardEntries
+                WHERE id = ?;
+            "#;
+
+            sqlx::query(query)
+                .bind(entry.creation)
+                .execute(&mut self.conn)
+                .await?;
+        }
+
+        if let Some(pos) = self.favorites.remove(&entry.creation) {
+            let query = r#"
+                UPDATE FavoriteClipboardEntries
+                SET position = position - 1
+                WHERE position >= ?;
+            "#;
+            sqlx::query(query)
+                .bind(pos as i32)
+                .execute(&mut self.conn)
+                .await?;
+        }
+
+        if let Some(e) = self.state.get_mut(&entry.creation) {
+            e.is_favorite = false;
+        }
+        Ok(())
+    }
+
+     fn favorite_len(&self) -> usize {
+        self.favorites.favorites.len()
+    }
+
+     fn search(&mut self) {
+        if self.query.is_empty() {
+            self.filtered.clear();
+        } else if let Some(atom) = &self.needle {
+            self.filtered = Self::iter_inner(&self.state, &self.favorites)
+                .filter_map(|data| {
+                    data.get_searchable_text().and_then(|text| {
+                        let mut buf = Vec::new();
+
+                        let haystack = Utf32Str::new(text, &mut buf);
+
+                        let mut indices = Vec::new();
+
+                        let _res = atom.indices(haystack, &mut self.matcher, &mut indices);
+
+                        if !indices.is_empty() {
+                            Some((data.creation, indices))
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .collect::<Vec<_>>();
+        }
+    }
+
+     fn set_query_and_search(&mut self, query: String) {
+        if query.is_empty() {
+            self.needle.take();
+        } else {
+            let atom = Atom::new(
+                &query,
+                CaseMatching::Smart,
+                Normalization::Smart,
+                AtomKind::Substring,
+                true,
+            );
+
+            self.needle.replace(atom);
+        }
+
+        self.query = query;
+
+        self.search();
+    }
+
+     fn query(&self) -> &str {
+        &self.query
+    }
+
+     fn get(&self, index: usize) -> Option<&Entry> {
+        if self.query.is_empty() {
+            self.iter().nth(index)
+        } else {
+            self.filtered
+                .get(index)
+                .map(|(id, _indices)| &self.state[id])
+        }
+    }
+
+     fn iter(&self) -> impl Iterator<Item = &'_ Entry> {
+        debug_assert!(self.query.is_empty());
+        Self::iter_inner(&self.state, &self.favorites)
+    }
+
+    
+
+     fn search_iter(&self) -> impl Iterator<Item = (&'_ Entry, &'_ Vec<u32>)> {
+        debug_assert!(!self.query.is_empty());
+
+        self.filtered
+            .iter()
+            .map(|(id, indices)| (&self.state[id], indices))
+    }
+
+     fn len(&self) -> usize {
+        if self.query.is_empty() {
+            self.state.len()
+        } else {
+            self.filtered.len()
+        }
+    }
+
+     async fn handle_message(&mut self, _message: DbMessage) -> Result<()> {
+        let data_version = fetch_data_version(&mut self.conn).await?;
+
+        if self.data_version != data_version {
+            self.reload().await?;
+        }
+
+        self.data_version = data_version;
+
+        Ok(())
+    }
+}
+
+impl Db {
+    
+    fn iter_inner<'a>(
+        state: &'a BTreeMap<Time, Entry>,
+        favorites: &'a Favorites,
+    ) -> impl Iterator<Item = &'a Entry> + 'a {
+        favorites
+            .fav()
+            .iter()
+            .filter_map(|id| state.get(id))
+            .chain(state.values().filter(|e| !e.is_favorite).rev())
+    }
+}
+/// https://www.sqlite.org/pragma.html#pragma_data_version
+async fn fetch_data_version(conn: &mut SqliteConnection) -> Result<i64> {
+    let data_version: i64 = sqlx::query("PRAGMA data_version")
+        .fetch_one(conn)
+        .await?
+        .get("data_version");
+
+    Ok(data_version)
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,5 +70,5 @@ fn main() -> cosmic::iced::Result {
         config_handler,
         config,
     };
-    cosmic::applet::run::<AppState>(flags)
+    cosmic::applet::run::<AppState<db::DbSqlite>>(flags)
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use crate::{
     clipboard::ClipboardMessage,
     config::Config,
-    db::{DbMessage, EntryId, EntryTrait},
+    db::{DbMessage, EntryId},
     navigation::EventMsg,
 };
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use crate::{
     clipboard::ClipboardMessage,
     config::Config,
-    db::{DbMessage, Entry},
+    db::{DbMessage, EntryId, EntryTrait},
     navigation::EventMsg,
 };
 
@@ -15,16 +15,16 @@ pub enum AppMsg {
     ClipboardEvent(ClipboardMessage),
     #[allow(dead_code)]
     RetryConnectingClipboard,
-    Copy(Entry),
-    Delete(Entry),
+    Copy(EntryId),
+    Delete(EntryId),
     Clear,
     Navigation(EventMsg),
     Db(DbMessage),
-    ShowQrCode(Entry),
+    ShowQrCode(EntryId),
     ReturnToClipboard,
     Config(ConfigMsg),
-    AddFavorite(Entry),
-    RemoveFavorite(Entry),
+    AddFavorite(EntryId),
+    RemoveFavorite(EntryId),
     NextPage,
     PreviousPage,
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -149,17 +149,19 @@ impl<Db: DbTrait> AppState<Db> {
                     .iter()
                     .enumerate()
                     .get(range)
-                    .filter_map(|(pos, data)| match data.viewable_content() {
-                        Ok(c) => match c {
-                            Content::Text(text) => self.text_entry(data, pos == self.focused, text),
-                            Content::Image(image) => {
-                                self.image_entry(data, pos == self.focused, image)
-                            }
-                            Content::UriList(uris) => {
-                                self.uris_entry(data, pos == self.focused, &uris)
-                            }
-                        },
-                        Err(_) => None,
+                    .filter_map(|(pos, data)| {
+                        data.preferred_content(&self.preferred_mime_types_regex)
+                            .and_then(|(_, content)| match content {
+                                Content::Text(text) => {
+                                    self.text_entry(data, pos == self.focused, text)
+                                }
+                                Content::Image(image) => {
+                                    self.image_entry(data, pos == self.focused, image)
+                                }
+                                Content::UriList(uris) => {
+                                    self.uris_entry(data, pos == self.focused, &uris)
+                                }
+                            })
                     })
                     .collect();
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -16,13 +16,13 @@ use itertools::Itertools;
 
 use crate::{
     app::AppState,
-    db::{Content, Entry},
+    db::{Content, DbTrait, EntryTrait},
     fl, icon_button,
     message::{AppMsg, ConfigMsg},
     utils::formatted_value,
 };
 
-impl AppState {
+impl <Db: DbTrait>AppState<Db> {
     pub fn quick_settings_view(&self) -> Element<'_, AppMsg> {
         fn toggle_settings<'a>(
             info: impl Into<Cow<'a, str>> + 'a,
@@ -215,7 +215,7 @@ impl AppState {
 
     fn image_entry<'a>(
         &'a self,
-        entry: &'a Entry,
+        entry: &'a Db::Entry,
         is_focused: bool,
         image_data: &'a [u8],
     ) -> Option<Element<'a, AppMsg>> {
@@ -226,7 +226,7 @@ impl AppState {
 
     fn uris_entry<'a>(
         &'a self,
-        entry: &'a Entry,
+        entry: &'a Db::Entry,
         is_focused: bool,
         uris: &[&'a str],
     ) -> Option<Element<'a, AppMsg>> {
@@ -255,7 +255,7 @@ impl AppState {
 
     fn text_entry_with_indices<'a>(
         &'a self,
-        entry: &'a Entry,
+        entry: &'a Db::Entry,
         is_focused: bool,
         content: &'a str,
         _indices: &'a [u32],
@@ -265,7 +265,7 @@ impl AppState {
 
     fn text_entry<'a>(
         &'a self,
-        entry: &'a Entry,
+        entry: &'a Db::Entry,
         is_focused: bool,
         content: &'a str,
     ) -> Option<Element<'a, AppMsg>> {
@@ -282,12 +282,12 @@ impl AppState {
 
     fn base_entry<'a>(
         &'a self,
-        entry: &'a Entry,
+        entry: &'a Db::Entry,
         is_focused: bool,
         content: impl Into<Element<'a, AppMsg>>,
     ) -> Element<'a, AppMsg> {
         let btn = button::custom(content)
-            .on_press(AppMsg::Copy(entry.clone()))
+            .on_press(AppMsg::Copy(entry.id()))
             .padding([8, 16])
             .class(Button::Custom {
                 active: Box::new(move |focused, theme| {
@@ -343,25 +343,25 @@ impl AppState {
             Some(vec![
                 menu::Tree::new(
                     button::text(fl!("delete_entry"))
-                        .on_press(AppMsg::Delete(entry.clone()))
+                        .on_press(AppMsg::Delete(entry.id()))
                         .width(Length::Fill)
                         .class(Button::Destructive),
                 ),
                 menu::Tree::new(
                     button::text(fl!("show_qr_code"))
-                        .on_press(AppMsg::ShowQrCode(entry.clone()))
+                        .on_press(AppMsg::ShowQrCode(entry.id()))
                         .width(Length::Fill),
                 ),
-                if entry.is_favorite {
+                if entry.is_favorite() {
                     menu::Tree::new(
                         button::text(fl!("remove_favorite"))
-                            .on_press(AppMsg::RemoveFavorite(entry.clone()))
+                            .on_press(AppMsg::RemoveFavorite(entry.id()))
                             .width(Length::Fill),
                     )
                 } else {
                     menu::Tree::new(
                         button::text(fl!("add_favorite"))
-                            .on_press(AppMsg::AddFavorite(entry.clone()))
+                            .on_press(AppMsg::AddFavorite(entry.id()))
                             .width(Length::Fill),
                     )
                 },

--- a/src/view.rs
+++ b/src/view.rs
@@ -146,7 +146,7 @@ impl<Db: DbTrait> AppState<Db> {
 
                 let entries_view: Vec<_> = self
                     .db
-                    .iter()
+                    .either_iter()
                     .enumerate()
                     .get(range)
                     .filter_map(|(pos, data)| {


### PR DESCRIPTION
Refractor of the DB code to fix this issue #104 .

Now we retrieve all mime types, instead of just custom ones

There is also various improvement, like using buffered query for sql, and async read of pipe when reading clipboard content.
And the Db now implement a Trait, to make the code cleaner.

Todo:
- fix the search
- fix issue where the clipboard is not visible in the applet
- better solution for prefered  mime type (make this a config option) and also use it for qr code
- 