### PR TITLE
Add keyboard shortcut feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
  "futures-util",
  "iced_futures",
  "known-folders",
- "notify",
+ "notify 8.2.0",
  "ron",
  "serde",
  "tokio",
@@ -1097,6 +1097,7 @@ dependencies = [
  "itertools",
  "libcosmic",
  "mime 0.3.17",
+ "notify 7.0.0",
  "nucleo",
  "open",
  "paste",
@@ -1748,6 +1749,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2880,6 +2893,17 @@ dependencies = [
 
 [[package]]
 name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
@@ -3544,20 +3568,48 @@ dependencies = [
 
 [[package]]
 name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.9.4",
+ "filetime",
+ "fsevent-sys",
+ "inotify 0.10.2",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types 1.0.1",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.9.4",
  "fsevent-sys",
- "inotify",
+ "inotify 0.11.0",
  "kqueue",
  "libc",
  "log",
  "mio",
- "notify-types",
+ "notify-types 2.0.0",
  "walkdir",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ itertools = "0.14"
 alive_lock_file = "0.2"
 regex = "1"
 open = "5"
+notify = "7.0"
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,31 @@ The goal is to make a simple yet fast clipboard history, with a focus on UX, rap
 
 There is a quick settings popup when you right click the icon.
 
+## Usage
+
+### Keyboard Shortcut (Recommended)
+
+You can set up a global keyboard shortcut to toggle the clipboard manager from anywhere:
+
+1. Open **COSMIC Settings** → **Keyboard** → **Custom Shortcuts**
+2. Click **Add Custom Shortcut**
+3. Fill in the details:
+   - **Name**: Clipboard Manager
+   - **Command**: `cosmic-ext-applet-clipboard-manager --toggle`
+   - **Shortcut**: Press **Super+V** (or your preferred key combination)
+
+Once set up, press your configured shortcut to open the clipboard manager, use arrow keys to navigate, and press Enter to select an item.
+
+### Command Line
+
+The applet supports the following command-line options:
+
+```sh
+cosmic-ext-applet-clipboard-manager --toggle    # Toggle the clipboard popup
+cosmic-ext-applet-clipboard-manager --help      # Show help message
+cosmic-ext-applet-clipboard-manager --version   # Show version information
+```
+
 ## Install
 
 Use the flatpak version in the cosmic store.

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,7 @@ use cosmic::{Element, app::Task};
 use futures::StreamExt;
 use futures::executor::block_on;
 use regex::Regex;
+use std::path::PathBuf;
 
 use crate::clipboard::ClipboardError;
 use crate::config::{Config, PRIVATE_MODE};
@@ -41,6 +42,12 @@ pub const ORG: &str = "cosmic_utils";
 pub const APP: &str = "cosmic-ext-applet-clipboard-manager";
 pub const APPID: &str = constcat::concat!(QUALIFIER, ".", ORG, ".", APP);
 
+fn get_signal_file_path() -> PathBuf {
+    let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(runtime_dir).join("cosmic-clipboard-manager-toggle")
+}
+
 pub struct AppState<Db: DbTrait> {
     core: Core,
     config_handler: cosmic_config::Config,
@@ -53,6 +60,7 @@ pub struct AppState<Db: DbTrait> {
     pub qr_code: Option<Result<qr_code::Data, ()>>,
     last_quit: Option<(i64, PopupKind)>,
     pub preferred_mime_types_regex: Vec<Regex>,
+    last_signal_content: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -181,9 +189,11 @@ impl<Db: DbTrait> AppState<Db> {
 
             self.last_quit = Some((Utc::now().timestamp_millis(), popup.kind));
 
-            if self.config.horizontal {
+            // Popup now always uses layer surface for reliable keyboard focus
+            if popup.kind == PopupKind::Popup {
                 destroy_layer_surface(popup.id)
             } else {
+                // QuickSettings still uses popup
                 destroy_popup(popup.id)
             }
         } else {
@@ -209,34 +219,28 @@ impl<Db: DbTrait> AppState<Db> {
 
         match kind {
             PopupKind::Popup => {
-                if self.config.horizontal {
-                    get_layer_surface(SctkLayerSurfaceSettings {
-                        id: new_id,
-                        keyboard_interactivity: KeyboardInteractivity::OnDemand,
-                        anchor: layer_surface::Anchor::BOTTOM
+                // Always use layer surface for external toggles to ensure keyboard focus
+                // Popups don't reliably receive keyboard focus when opened programmatically
+                get_layer_surface(SctkLayerSurfaceSettings {
+                    id: new_id,
+                    keyboard_interactivity: KeyboardInteractivity::Exclusive,
+                    anchor: if self.config.horizontal {
+                        layer_surface::Anchor::BOTTOM
                             | layer_surface::Anchor::LEFT
-                            | layer_surface::Anchor::RIGHT,
-                        namespace: "clipboard manager".into(),
-                        size: Some((None, Some(350))),
-                        size_limits: Limits::NONE.min_width(1.0).min_height(1.0),
-                        ..Default::default()
-                    })
-                } else {
-                    let mut popup_settings = self.core.applet.get_popup_settings(
-                        self.core.main_window_id().unwrap(),
-                        new_id,
-                        None,
-                        None,
-                        None,
-                    );
-
-                    popup_settings.positioner.size_limits = Limits::NONE
-                        .min_width(300.0)
-                        .max_width(400.0)
-                        .min_height(200.0)
-                        .max_height(500.0);
-                    get_popup(popup_settings)
-                }
+                            | layer_surface::Anchor::RIGHT
+                    } else {
+                        // Position at top-right for vertical layout
+                        layer_surface::Anchor::TOP | layer_surface::Anchor::RIGHT
+                    },
+                    namespace: "clipboard manager".into(),
+                    size: if self.config.horizontal {
+                        Some((None, Some(350)))
+                    } else {
+                        Some((Some(400), Some(530)))
+                    },
+                    size_limits: Limits::NONE.min_width(1.0).min_height(1.0),
+                    ..Default::default()
+                })
             }
             PopupKind::QuickSettings => {
                 let mut popup_settings = self.core.applet.get_popup_settings(
@@ -301,6 +305,7 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                 })
                 .collect(),
             config,
+            last_signal_content: None,
         };
 
         #[cfg(debug_assertions)]
@@ -336,6 +341,36 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
         }
 
         match message {
+            AppMsg::CheckSignalFile => {
+                let signal_file = get_signal_file_path();
+                if let Ok(content) = std::fs::read_to_string(&signal_file) {
+                    if self.last_signal_content.as_ref() != Some(&content) {
+                        self.last_signal_content = Some(content);
+ 
+                        // Clear last_quit for external toggles to ensure it works
+                        self.last_quit = None;
+
+                        // If popup is open, close it. If closed, open it
+                        if self.popup.is_some() {
+                            // Close the popup but don't set last_quit for external toggles
+                            self.focused = 0;
+                            self.page = 0;
+                            self.db.set_query_and_search("".into());
+
+                            if let Some(popup) = self.popup.take() {
+                                // Popup now always uses layer surface
+                                if popup.kind == PopupKind::Popup {
+                                    return destroy_layer_surface(popup.id);
+                                } else {
+                                    return destroy_popup(popup.id);
+                                }
+                            }
+                        } else {
+                            return self.open_popup(PopupKind::Popup);
+                        }
+                    }
+                }
+            }
             AppMsg::ChangeConfig(config) => {
                 if config.private_mode != self.config.private_mode {
                     PRIVATE_MODE.store(config.private_mode, atomic::Ordering::Relaxed);
@@ -566,10 +601,15 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
             cosmic::iced::time::every(Duration::from_millis(1000)).map(|_| DbMessage::CheckUpdate)
         }
 
+        fn signal_file_checker() -> Subscription<AppMsg> {
+            cosmic::iced::time::every(Duration::from_millis(100)).map(|_| AppMsg::CheckSignalFile)
+        }
+
         let mut subscriptions = vec![
             config::sub(),
             navigation::sub().map(AppMsg::Navigation),
             db_sub().map(AppMsg::Db),
+            signal_file_checker(),
         ];
 
         if !self.clipboard_state.is_error() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,23 @@ pub struct Config {
     pub unique_session: bool,
     pub maximum_entries_by_page: NonZeroU32,
     pub preferred_mime_types: Vec<String>,
+    /// Keyboard shortcut to toggle clipboard manager
+    pub keyboard_shortcut: KeyboardShortcut,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub struct KeyboardShortcut {
+    pub modifiers: Vec<String>,
+    pub key: String,
+}
+
+impl Default for KeyboardShortcut {
+    fn default() -> Self {
+        Self {
+            modifiers: vec!["Super".to_string()],
+            key: "V".to_string(),
+        }
+    }
 }
 
 pub static PRIVATE_MODE: AtomicBool = AtomicBool::new(false);
@@ -56,6 +73,7 @@ impl Default for Config {
             unique_session: false,
             maximum_entries_by_page: NonZero::new(50).unwrap(),
             preferred_mime_types: Vec::new(),
+            keyboard_shortcut: KeyboardShortcut::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,23 +35,6 @@ pub struct Config {
     pub unique_session: bool,
     pub maximum_entries_by_page: NonZeroU32,
     pub preferred_mime_types: Vec<String>,
-    /// Keyboard shortcut to toggle clipboard manager
-    pub keyboard_shortcut: KeyboardShortcut,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
-pub struct KeyboardShortcut {
-    pub modifiers: Vec<String>,
-    pub key: String,
-}
-
-impl Default for KeyboardShortcut {
-    fn default() -> Self {
-        Self {
-            modifiers: vec!["Super".to_string()],
-            key: "V".to_string(),
-        }
-    }
 }
 
 pub static PRIVATE_MODE: AtomicBool = AtomicBool::new(false);
@@ -73,7 +56,6 @@ impl Default for Config {
             unique_session: false,
             maximum_entries_by_page: NonZero::new(50).unwrap(),
             preferred_mime_types: Vec::new(),
-            keyboard_shortcut: KeyboardShortcut::default(),
         }
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -48,6 +48,7 @@ pub fn send_toggle_signal() -> std::io::Result<()> {
 pub fn signal_file_watcher() -> Subscription<AppMsg> {
     use notify::{Watcher, RecursiveMode, Event};
     use futures::stream;
+    use tokio::time::{sleep, Duration};
  
     Subscription::run_with_id(
         "signal_file_watcher",
@@ -76,6 +77,9 @@ pub fn signal_file_watcher() -> Subscription<AppMsg> {
 
                 // Wait for file change notification
                 rx.recv().await;
+
+                // Add a 10ms pause to prevent stressing cpu
+                sleep(Duration::from_millis(10)).await;
             }
 
             Some((AppMsg::CheckSignalFile, ()))

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,0 +1,84 @@
+//! IPC mechanism for external toggle functionality via file-based signaling.
+//!
+//! This module provides a simple IPC mechanism using a signal file in XDG_RUNTIME_DIR.
+//! When the `--toggle` command is invoked, it writes a timestamp to the signal file.
+//! The timestamp ensures the file content changes on each toggle, which triggers
+//! the file watcher to notify the app to toggle the popup.
+
+use std::path::PathBuf;
+use std::fs;
+use std::time::SystemTime;
+
+use cosmic::iced_futures::Subscription;
+use crate::message::AppMsg;
+
+/// Get the signal file path for IPC toggle functionality.
+/// Returns None if XDG_RUNTIME_DIR is not set.
+pub fn get_signal_file_path() -> Option<PathBuf> {
+    std::env::var("XDG_RUNTIME_DIR").ok().map(|runtime_dir| {
+        PathBuf::from(runtime_dir).join("cosmic-clipboard-manager-toggle")
+    })
+}
+
+/// Send a toggle signal by writing a timestamp to the signal file.
+/// The timestamp ensures the file content changes, triggering the file watcher.
+pub fn send_toggle_signal() -> std::io::Result<()> {
+    let signal_file = get_signal_file_path().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "XDG_RUNTIME_DIR not set - cannot send toggle signal"
+        )
+    })?;
+ 
+    // Write current timestamp to signal file.
+    // The timestamp value itself isn't used, but ensures the file content changes
+    // on each toggle, which triggers the file watcher to detect the change.
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+        .as_millis()
+        .to_string();
+    
+    fs::write(&signal_file, timestamp)?;
+    Ok(())
+}
+
+/// Create a file watcher subscription that monitors the signal file for changes.
+/// When the file is modified, it sends a CheckSignalFile message to toggle the popup.
+pub fn signal_file_watcher() -> Subscription<AppMsg> {
+    use notify::{Watcher, RecursiveMode, Event};
+    use futures::stream;
+ 
+    Subscription::run_with_id(
+        "signal_file_watcher",
+        stream::unfold((), |_| async {
+            // Only set up watcher if XDG_RUNTIME_DIR is set
+            let signal_file = match get_signal_file_path() {
+                Some(path) => path,
+                None => {
+                    // If XDG_RUNTIME_DIR is not set, just wait forever
+                    futures::future::pending::<()>().await;
+                    return Some((AppMsg::CheckSignalFile, ()));
+                }
+            };
+
+            let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+            
+            let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
+                if res.is_ok() {
+                    let _ = tx.blocking_send(());
+                }
+            }).ok()?;
+
+            // Watch the signal file's parent directory since the file might not exist yet
+            if let Some(parent) = signal_file.parent() {
+                let _ = watcher.watch(parent, RecursiveMode::NonRecursive);
+
+                // Wait for file change notification
+                rx.recv().await;
+            }
+
+            Some((AppMsg::CheckSignalFile, ()))
+        })
+    )
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ use config::{CONFIG_VERSION, Config};
 use cosmic::cosmic_config;
 use cosmic::cosmic_config::CosmicConfigEntry;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
 
 mod app;
 mod clipboard;
@@ -21,15 +24,42 @@ mod navigation;
 mod utils;
 mod view;
 
+// Signal file path for IPC
+fn get_signal_file_path() -> PathBuf {
+    let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(runtime_dir).join("cosmic-clipboard-manager-toggle")
+}
+
+fn send_toggle_signal() -> std::io::Result<()> {
+    let signal_file = get_signal_file_path();
+    // Write current timestamp to signal file
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .to_string();
+    fs::write(&signal_file, timestamp)?;
+    Ok(())
+}
+
 #[allow(unused_imports)]
 #[macro_use]
 extern crate tracing;
 
 fn setup_logs() {
     let fmt_layer = fmt::layer().with_target(true);
+
+    #[cfg(debug_assertions)]
+    let default_level = "info";
+    #[cfg(not(debug_assertions))]
+    let default_level = "warn";
+
     let filter_layer = EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new(format!(
-        "warn,{}=warn",
-        env!("CARGO_CRATE_NAME")
+        "{},{}={}",
+        default_level,
+        env!("CARGO_CRATE_NAME"),
+        default_level
     )));
 
     if let Ok(journal_layer) = tracing_journald::layer() {
@@ -47,12 +77,43 @@ fn setup_logs() {
 }
 
 fn main() {
-    for arg in std::env::args().skip(1) {
+    // Check for command-line arguments before initializing the app
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    for arg in &args {
         if arg == "-V" || arg == "--version" {
             let version = env!("CARGO_PKG_VERSION");
             let commit = option_env!("CLIPBOARD_MANAGER_COMMIT").unwrap_or("unknown");
 
             println!("clipboard-manager {version} (commit {commit})");
+            return;
+        }
+
+        if arg == "--toggle" || arg == "-t" {
+            if let Err(e) = send_toggle_signal() {
+                eprintln!("Failed to toggle clipboard manager: {}", e);
+                std::process::exit(1);
+            }
+            return;
+        }
+
+        if arg == "-h" || arg == "--help" {
+            println!("COSMIC Clipboard Manager");
+            println!();
+            println!("USAGE:");
+            println!("    cosmic-ext-applet-clipboard-manager [OPTIONS]");
+            println!();
+            println!("OPTIONS:");
+            println!("    -t, --toggle     Toggle the clipboard manager popup");
+            println!("    -V, --version    Print version information");
+            println!("    -h, --help       Print this help message");
+            println!();
+            println!("KEYBOARD SHORTCUT SETUP:");
+            println!("    1. Open COSMIC Settings → Keyboard → Custom Shortcuts");
+            println!("    2. Click 'Add Custom Shortcut'");
+            println!("    3. Name: Clipboard Manager");
+            println!("    4. Command: cosmic-ext-applet-clipboard-manager --toggle");
+            println!("    5. Shortcut: Press Super+V (or your preferred shortcut)");
             return;
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -26,6 +26,7 @@ pub enum AppMsg {
     PreviousPage,
     ContextMenu(ContextMenuMsg),
     LinkClicked(markdown::Url),
+    CheckSignalFile,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]

--- a/src/view.rs
+++ b/src/view.rs
@@ -94,17 +94,19 @@ impl<Db: DbTrait> AppState<Db> {
             .push(
                 container(
                     row()
-                        .push(
+                        .push({
+                            let focused_id = self.db.get(self.focused).map(|d| d.id());
                             text_input::search_input(fl!("search_entries"), self.db.get_query())
                                 .always_active()
                                 .on_input(AppMsg::Search)
                                 .on_paste(AppMsg::Search)
                                 .on_clear(AppMsg::Search("".into()))
+                                .on_submit_maybe(focused_id.map(|id| move |_| AppMsg::Copy(id)))
                                 .width(match self.config.horizontal {
                                     true => Length::Fixed(250f32),
                                     false => Length::Fill,
-                                }),
-                        )
+                                })
+                        })
                         .push(horizontal_space().width(5))
                         .push(icon_button!("arrow_back_ios_new24").on_press_maybe(
                             if self.page > 0 {


### PR DESCRIPTION
This adds the ability to assign keyboard shortcuts via the Cosmic keyboard custom settings to activate, search, select, and copy from the UI.

The command to add is:

```
cosmic-ext-applet-clipboard-manager --toggle
```

and you can assign it to any shortcut. This will show/hide the clipboard manager, and allow you to type to search, use the arrow keys to select an item, and enter to copy and close the interface. Escape also works to exit without selecting anything.

Full disclosure: I am not an expert in Rust; I'm scratching my own itch to add this feature, so there may be a more suitable way of doing this.

---

- closes https://github.com/cosmic-utils/clipboard-manager/issues/158
