### PR TITLE
feat(ui): Add button to clear non-favorite entries

### DIFF
--- a/res/icons/trash-bin.svg
+++ b/res/icons/trash-bin.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" width="24px" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="3 6 5 6 21 6"/>
+    <path d="M19 6 18.333 19a2 2 0 0 1-2 2H7.667a2 2 0 0 1-2-2L5 6"/>
+    <line x1="10" y1="11" x2="10" y2="17"/>
+    <line x1="14" y1="11" x2="14" y2="17"/>
+    <line x1="8" y1="6" x2="8" y2="4"/>
+    <line x1="16" y1="6" x2="16" y2="4"/>
+</svg>

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -208,6 +208,8 @@ pub trait DbTrait: Sized {
     fn is_search_active(&self) -> bool {
         !self.get_query().is_empty()
     }
+
+    fn non_favorite_count(&self) -> usize;
 }
 
 #[derive(Clone, Debug)]

--- a/src/db/sqlite_db.rs
+++ b/src/db/sqlite_db.rs
@@ -707,6 +707,10 @@ impl DbTrait for DbSqlite {
 
         Ok(())
     }
+
+    fn non_favorite_count(&self) -> usize {
+        self.entries.values().filter(|entry| !entry.is_favorite).count()
+    }
 }
 
 /// https://www.sqlite.org/pragma.html#pragma_data_version

--- a/src/view.rs
+++ b/src/view.rs
@@ -119,8 +119,19 @@ impl<Db: DbTrait> AppState<Db> {
                             } else {
                                 None
                             },
-                        )),
-                )
+                        ))
+                        .push(
+                        icon_button!("trash-bin")
+                            .on_press_maybe(
+                                if self.db.non_favorite_count() > 0 {
+                                    Some(AppMsg::Clear)
+                                } else {
+                                    None
+                                },
+                            )
+                            .padding([8, 12])
+
+                    ))
                 .padding(padding::all(15f32).bottom(0)),
             )
             .push(


### PR DESCRIPTION
This pull request introduces a new UI feature that allows users to **quickly clear all non-favorite clipboard entries**.

---

### **Changes Made**

* Added a **trash bin icon** (`res/icons/trash-bin.svg`) to represent the clear action.
*  Updated `DbTrait` to include a new method:

  ```rust
  fn non_favorite_count(&self) -> usize;
  ```
* Implemented the method in `sqlite_db.rs` to count non-favorite entries.
* Modified the view (`src/view.rs`) to:

  * Display a **trash icon button** in the UI.
  * Enable the button **only when** there are non-favorite entries.
  * Trigger the `AppMsg::Clear` event on click.

---

### **Behavior**

* The button is visible in the toolbar.
* It becomes **inactive** when there are no non-favorite entries.
* When clicked, it triggers the clear action to remove all non-favorites.
---

### **Why This Change**

Improves UX by providing a **quick way to clean up** clipboard history while keeping favorite items safe.