### PR TITLE
i18n: add Russian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There is a quick settings popup when you right click the icon.
 ## Install
 
 > [!WARNING]  
-> The applet is available in the cosmic-store, however, this version will currently not work (https://github.com/cosmic-utils/clipboard-manager/issues/171). 
+> The applet is available in the cosmic-store, however, this version will currently not work (https://github.com/cosmic-utils/clipboard-manager/issues/171).
 
 The reason is because this applet use a wayland protocol ([data control protocol](https://wayland.app/protocols/ext-data-control-v1)) which is not available for sandboxed client.
 The only way is to build from source. For this you need to install [rust](https://rust-lang.org/tools/install/), [just](https://github.com/casey/just), and follow the the [build instruction](./BUILD.md).

--- a/i18n/ru/cosmic_ext_applet_clipboard_manager.ftl
+++ b/i18n/ru/cosmic_ext_applet_clipboard_manager.ftl
@@ -1,0 +1,19 @@
+search_entries = Поиск
+delete_entry = Удалить
+incognito = Инкогнито
+clear_entries = Очистить
+show_qr_code = Показать QR код
+return_to_clipboard = Вернуть в буфер обмена
+qr_code_error = Ошибка при генерации QR кода
+horizontal_layout = Горизонтальный
+add_favorite = Добавить в Избранное
+remove_favorite = Удалить из Избранного
+unique_session = Уникальная сессия
+unknown_mime_types_title = Типы mime
+
+data_control = Dummy
+    .title = Вам необходимо активировать протокол Wayland "data control" на вашем устройстве
+    .explanation =
+        Для работы этого апплета требуется [протокол управления данными (data control protocol)](https://wayland.app/protocols/ext-data-control-v1). Он позволяет любому привилегированному клиенту получать доступ к буферу обмена без действий со стороны пользователя. Это может быть небезопасно.
+    .cosmic = 
+        В рабочем окружении COSMIC этот протокол по умолчанию отключен, но вы можете включить его следующей командой:

--- a/res/desktop_entry.desktop
+++ b/res/desktop_entry.desktop
@@ -6,6 +6,7 @@ Name[de]=Zwischenablage Verwaltung
 Name[es]=Gestor de portapapeles
 Name[hu]=Vágólapkezelő
 Name[pt]=Gestor da Área de Transferência
+Name[ru]=Менеджер буфера обмена
 Comment=A wayland clipboard manager
 Comment[ar]=مدير حافظة وايلاند
 Comment[cs]=Manažer schránky pro Wayland
@@ -13,12 +14,14 @@ Comment[de]=Eine Zwischenablage Verwaltung für Wayland
 Comment[es]=Gestor de portapapeles wayland
 Comment[hu]=Wayland vágólapkezelő
 Comment[pt]=Miniaplicativo para gerenciar itens copiados no sistema
+Comment[ru]=Менеджер буфера обмена для Wayland
 Keywords=Cosmic;Iced;history;
 Keywords[cs]=clipboard;schránka;historie;
 Keywords[de]=Cosmic;historie;verlauf;Zwischenablage
 Keywords[es]=Cosmic;Iced;historial;portapapeles;
 Keywords[hu]=előzmények
 Keywords[pt]=clipboard;histórico;
+Keywords[ru]=cosmic;iced;история;буфер;обмен;
 
 # translators: do not translate this part
 Icon=io.github.cosmic_utils.cosmic-ext-applet-clipboard-manager-symbolic

--- a/res/metainfo.xml
+++ b/res/metainfo.xml
@@ -9,10 +9,12 @@
     <name xml:lang="cs">Manažer schránky</name>
     <name xml:lang="de">Zwischenablage Verwaltung</name>
     <name xml:lang="hu">Vágólapkezelő</name>
+    <name xml:lang="ru">Менеджер буфера обмена</name>
     <summary>A wayland clipboard manager</summary>
     <summary xml:lang="cs">Manažer schránky pro Wayland</summary>
     <summary xml:lang="de">Eine Zwischenablage Verwaltung für Wayland</summary>
     <summary xml:lang="hu">Wayland vágólapkezelő</summary>
+    <summary xml:lang="ru">Менеджер буфера обмена для Wayland</summary>
 
     <metadata_license>MIT</metadata_license>
     <project_license>GPL-3.0-only</project_license>
@@ -47,6 +49,8 @@
             Funktioniert nur in Wayland mit dem Datenkontrollprotokoll (data control protocol).</p>    <!--the contents in the parenthesis are for better understanding while troubleshooting-->
         <p xml:lang="hu">Vágólapkezelő COSMIC kisalkalmazás, amely támogatja a képeket és más MIME-típusokat. 
            Csak Waylanden működik az adatvezérlő protokoll használatával.</p>
+        <p xml:lang="ru">Апплет буфера обмена COSMIC с поддержкой изображений и других типов MIME. 
+           Работает только в Wayland с использованием протокола управления данными.</p>
     </description>
 
 
@@ -60,6 +64,7 @@
             <caption xml:lang="cs">Ukázka appletu.</caption>
             <caption xml:lang="de">Das Applet.</caption>
             <caption xml:lang="hu">A kisalkalmazás.</caption>
+            <caption xml:lang="ru">Апплет.</caption>
         </screenshot>
     </screenshots>
 


### PR DESCRIPTION
Added Russian localization for app strings, desktop entry, and metainfo. Also cleaned up trailing whitespaces in README.