### PR TITLE
Respect password manager clipboard clearing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -41,6 +41,11 @@ pub const ORG: &str = "cosmic_utils";
 pub const APP: &str = "cosmic-ext-applet-clipboard-manager";
 pub const APPID: &str = constcat::concat!(QUALIFIER, ".", ORG, ".", APP);
 
+/// MIME type set by password managers (e.g. KeePassXC) to indicate sensitive clipboard content.
+/// When present, the entry should not be stored in clipboard history and the clipboard should
+/// not be restored when the source application clears it.
+const PASSWORD_MANAGER_HINT_MIME: &str = "x-kde-passwordManagerHint";
+
 pub struct AppState<Db: DbTrait> {
     core: Core,
     config_handler: cosmic_config::Config,
@@ -53,6 +58,9 @@ pub struct AppState<Db: DbTrait> {
     pub qr_code: Option<Result<qr_code::Data, ()>>,
     last_quit: Option<(i64, PopupKind)>,
     pub preferred_mime_types_regex: Vec<Regex>,
+    /// Tracks whether the last clipboard entry was sensitive (e.g. from a password manager).
+    /// When true, the clipboard will not be restored on clear.
+    last_entry_sensitive: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -289,6 +297,7 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
             qr_code: None,
             last_quit: None,
             page: 0,
+            last_entry_sensitive: false,
             preferred_mime_types_regex: config
                 .preferred_mime_types
                 .iter()
@@ -370,8 +379,14 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                     self.clipboard_state = ClipboardState::Connected;
                 }
                 clipboard::ClipboardMessage::Data(data) => {
-                    if let Err(e) = block_on(self.db.insert(data)) {
-                        error!("can't insert data: {e}");
+                    if data.contains_key(PASSWORD_MANAGER_HINT_MIME) {
+                        info!("clipboard contains password manager hint, skipping storage");
+                        self.last_entry_sensitive = true;
+                    } else {
+                        self.last_entry_sensitive = false;
+                        if let Err(e) = block_on(self.db.insert(data)) {
+                            error!("can't insert data: {e}");
+                        }
                     }
                 }
                 #[expect(irrefutable_let_patterns)]
@@ -388,7 +403,10 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                     };
                 }
                 clipboard::ClipboardMessage::EmptyKeyboard => {
-                    if let Some(data) = self.db.get(0) {
+                    if self.last_entry_sensitive {
+                        info!("clipboard cleared by password manager, not restoring");
+                        self.last_entry_sensitive = false;
+                    } else if let Some(data) = self.db.get(0) {
                         return copy_iced(data.raw_content().clone());
                     }
                 }


### PR DESCRIPTION
## Summary

- Skip storing clipboard entries that contain the `x-kde-passwordManagerHint` MIME type (set by KeePassXC and other password managers)
- When the source app clears the clipboard after a sensitive entry, do not restore it from history
- Passwords never enter the clipboard history DB, and the clipboard is allowed to clear naturally

## Root cause

When KeePassXC copies a password, it sets a timer to clear the clipboard after a configurable delay (default 10 seconds). On Wayland, clearing the clipboard sends a `Selection { id: None }` event, which the clipboard manager interprets as `EmptyKeyboard` and immediately restores the most recent entry from the database — which is the password that was just supposed to be cleared.

## How the fix works

1. When `ClipboardMessage::Data` arrives, check if the MIME types contain `x-kde-passwordManagerHint`
2. If present, skip inserting into the database and set `last_entry_sensitive = true`
3. When `ClipboardMessage::EmptyKeyboard` fires and `last_entry_sensitive` is true, skip the clipboard restoration

This is a well-known MIME type convention used by KeePassXC, KeePass, and other password managers on KDE/Qt systems.

## Test plan

- [x] Copy a password from KeePassXC — verify it does NOT appear in clipboard history
- [x] Paste the password while KeePassXC timer is active — verify paste works normally
- [x] Wait for KeePassXC's clear timer to expire — verify clipboard is empty (paste yields nothing)
- [x] Copy normal (non-password) text — verify it still appears in clipboard history as before

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)