### PR TITLE
Fix memory leaks: offers HashMap, dead events Vec, runtime eviction

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -36,7 +36,7 @@ enum WatchRes<I> {
 }
 
 pub fn sub() -> impl Stream<Item = ClipboardMessage> {
-    channel(500, move |mut output| {
+    channel(50, move |mut output| {
         async move {
             match clipboard_watcher::Watcher::init() {
                 Ok(mut clipboard_watcher) => {

--- a/src/clipboard_watcher.rs
+++ b/src/clipboard_watcher.rs
@@ -92,11 +92,6 @@ impl SeatData {
     }
 }
 
-pub struct Event {
-    pub event: ZwlrDataControlOfferV1,
-    pub data: HashSet<String>,
-}
-
 pub struct CommonState {
     pub seats: Vec<(WlSeat, SeatData)>,
     pub clipboard_manager: ZwlrDataControlManagerV1,
@@ -137,8 +132,6 @@ struct State {
     // TODO: We never remove offers from here, even if we don't use them or after destroying them.
     offers: HashMap<ZwlrDataControlOfferV1, HashSet<String>>,
     got_primary_selection: bool,
-    // waker: Waker,
-    events: Vec<Event>,
 }
 
 delegate_dispatch!(State: [WlSeat: ()] => CommonState);
@@ -184,14 +177,16 @@ impl Dispatch<ZwlrDataControlDeviceV1, WlSeat> for State {
     ) {
         match event {
             zwlr_data_control_device_v1::Event::DataOffer { id } => {
-                state.offers.insert(id.clone(), HashSet::new());
-                state.events.push(Event {
-                    event: id,
-                    data: HashSet::new(),
-                })
+                state.offers.insert(id, HashSet::new());
             }
             zwlr_data_control_device_v1::Event::Selection { id } => {
-                state.common.get_mut_seat(seat).unwrap().set_offer(id);
+                let seat_data = state.common.get_mut_seat(seat).unwrap();
+                // Remove the old offer from state.offers to prevent unbounded growth
+                if let Some(old_offer) = seat_data.offer.take() {
+                    state.offers.remove(&old_offer);
+                    old_offer.destroy();
+                }
+                seat_data.offer = id;
             }
             zwlr_data_control_device_v1::Event::Finished => {
                 // Destroy the device stored in the seat as it's no longer valid.
@@ -199,11 +194,13 @@ impl Dispatch<ZwlrDataControlDeviceV1, WlSeat> for State {
             }
             zwlr_data_control_device_v1::Event::PrimarySelection { id } => {
                 state.got_primary_selection = true;
-                state
-                    .common
-                    .get_mut_seat(seat)
-                    .unwrap()
-                    .set_primary_offer(id);
+                let seat_data = state.common.get_mut_seat(seat).unwrap();
+                // Remove the old primary offer from state.offers to prevent unbounded growth
+                if let Some(old_offer) = seat_data.primary_offer.take() {
+                    state.offers.remove(&old_offer);
+                    old_offer.destroy();
+                }
+                seat_data.primary_offer = id;
             }
             _ => (),
         }
@@ -340,7 +337,6 @@ impl Watcher {
             common,
             offers: HashMap::new(),
             got_primary_selection: false,
-            events: Vec::new(),
         };
 
         Ok(Watcher {

--- a/src/db/sqlite_db.rs
+++ b/src/db/sqlite_db.rs
@@ -49,6 +49,7 @@ pub struct DbSqlite {
     data_version: i64,
     pub(super) favorites: Favorites,
     lock: LockFile,
+    max_entries: Option<u32>,
 }
 
 #[derive(Clone)]
@@ -293,6 +294,7 @@ impl DbTrait for DbSqlite {
             matcher: Matcher::new(nucleo::Config::DEFAULT).into(),
             favorites: Favorites::default(),
             lock,
+            max_entries: config.maximum_entries_number,
         };
 
         db.reload().await?;
@@ -471,6 +473,37 @@ impl DbTrait for DbSqlite {
             self.times.insert(entry.creation, id);
             self.hashs.insert(hash, id);
             self.entries.insert(id, entry);
+        }
+
+        // Evict oldest non-favorite entries if over the max_entries limit
+        if let Some(max) = self.max_entries {
+            while self.entries.len() > max as usize {
+                // Find oldest non-favorite entry (earliest time in BTreeMap)
+                let oldest = self
+                    .times
+                    .iter()
+                    .find(|(_, id)| !self.favorites.contains(id))
+                    .map(|(time, id)| (*time, *id));
+
+                match oldest {
+                    Some((time, id)) => {
+                        self.times.remove(&time);
+                        if let Some(entry) = self.entries.remove(&id) {
+                            self.hashs.remove(&entry.get_hash());
+                        }
+
+                        let query_evict = r#"
+                            DELETE FROM ClipboardEntries
+                            WHERE id = ?;
+                        "#;
+                        sqlx::query(query_evict)
+                            .bind(id)
+                            .execute(&mut self.conn)
+                            .await?;
+                    }
+                    None => break, // Only favorites remain
+                }
+            }
         }
 
         self.search();


### PR DESCRIPTION
## Summary
- **Fix unbounded `offers` HashMap growth**: Remove old offers from `state.offers` when replaced by `Selection` and `PrimarySelection` events, preventing the HashMap from growing without bound on every clipboard operation
- **Remove dead `Event` struct and `events` Vec**: These were pushed to on every `DataOffer` event but never read — pure memory waste
- **Add runtime entry eviction in `DbSqlite`**: Evict oldest non-favorite entries after insert when over the configured `maximum_entries_number` limit, keeping in-memory collections bounded
- **Reduce iced channel buffer from 500 to 50**: Caps max buffered clipboard data at ~250MB instead of ~2.5GB

## Context
Issue #152 reports unbounded RAM growth (up to 10GB) during clipboard operations. The three root causes were:
1. `offers` HashMap in `clipboard_watcher.rs` never had entries removed — every clipboard event added an entry but only `start_watching` removed the *current* offer, leaving all previous offers leaked
2. `events: Vec<Event>` was pushed to on every `DataOffer` but never consumed
3. `DbSqlite` enforced `maximum_entries_number` only at startup, not at runtime — entries accumulated in memory without bound between restarts

## Test plan
- [ ] `cargo build --release` compiles clean
- [ ] Monitor RSS with `watch -n 1 "ps -p $(pgrep -f cosmic-ext-applet-clipboard) -o rss --no-headers"` during repeated clipboard operations — RSS should stay stable
- [ ] Verify icon click popup and keyboard shortcut toggle still work
- [ ] Verify favorites are not evicted by the max_entries enforcement

Fixes #152
Related: #159, #181, #186, #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)