### PR TITLE
feat: add D-Bus Toggle method for external shortcut support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
  "tracing",
  "tracing-journald",
  "tracing-subscriber",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ include_dir = "0.7"
 itertools = "0.14"
 regex = "1"
 open = "5"
+zbus = "5.1"
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic"

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,7 @@ use crate::message::{AppMsg, ConfigMsg, ContextMenuMsg};
 use crate::navigation::EventMsg;
 use crate::utils::task_message;
 use crate::view::SCROLLABLE_ID;
-use crate::{clipboard, clipboard_watcher, config, navigation};
+use crate::{clipboard, clipboard_watcher, config, navigation, dbus};
 
 use cosmic::{cosmic_config, iced_runtime};
 use std::sync::atomic::{self};
@@ -570,6 +570,7 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
             config::sub(),
             navigation::sub().map(AppMsg::Navigation),
             db_sub().map(AppMsg::Db),
+            Subscription::run(dbus::sub),
         ];
 
         if !self.clipboard_state.is_error() {

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -1,0 +1,47 @@
+use zbus::{interface, connection};
+use cosmic::iced::{futures::SinkExt, stream::channel};
+use futures::Stream;
+use crate::message::AppMsg;
+
+pub struct ClipboardInterface {
+    tx: tokio::sync::mpsc::Sender<()>,
+}
+
+#[interface(name = "io.github.cosmic_utils.ClipboardManager")]
+impl ClipboardInterface {
+    async fn toggle(&self) {
+        eprintln!("D-Bus: Toggle called!");
+        let _ = self.tx.send(()).await;
+    }
+}
+
+pub fn sub() -> impl Stream<Item = AppMsg> {
+    channel(1, async |mut output| {
+        eprintln!("D-Bus: Starting D-Bus server...");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let interface = ClipboardInterface { tx };
+        
+        let connection = connection::Builder::session()
+            .unwrap()
+            .name("io.github.cosmic_utils.ClipboardManager")
+            .unwrap()
+            .serve_at("/io/github/cosmic_utils/ClipboardManager", interface)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+
+        eprintln!("D-Bus: Server running at /io/github/cosmic_utils/ClipboardManager");
+
+        loop {
+            if rx.recv().await.is_some() {
+                eprintln!("D-Bus: Relaying TogglePopup message");
+                let _ = output.send(AppMsg::TogglePopup).await;
+            } else {
+                break;
+            }
+        }
+        
+        drop(connection);
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod clipboard;
 mod clipboard_watcher;
 mod config;
 mod db;
+mod dbus;
 mod icon;
 mod localize;
 mod message;


### PR DESCRIPTION
This PR adds a D-Bus interface (`io.github.cosmic_utils.ClipboardManager`) with a `Toggle` method to the clipboard applet.

### Purpose
Currently, the clipboard manager popup can only be triggered by a mouse click on the panel icon. There is no native way to bind a keyboard shortcut to open the clipboard history. 

This change allows users to bind a keyboard shortcut to a simple command like:
`busctl --user call io.github.cosmic_utils.ClipboardManager /io/github/cosmic_utils/ClipboardManager io.github.cosmic_utils.ClipboardManager Toggle`

This provides a robust workaround for the missing shortcut support in Cosmic without requiring deep changes to the compositor or settings daemon.

### Changes
- Added `zbus` dependency.
- Created `src/dbus.rs` to handle the D-Bus interface and relay messages to the app loop.
- Integrated the D-Bus subscription into `src/app.rs`.
- Added the `dbus` module to `main.rs`.